### PR TITLE
Place log always in output/logs directory

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,7 +4,7 @@ omit=venv*
 branch = True
 
 [report]
-omit=venv*, node_modules, **/migrations/**, scripts/*
+omit=venv*, node_modules, **/migrations/**, scripts/*, setup.py
 # Regexes for lines to exclude from consideration
 exclude_lines =
     # Have to re-enable the standard pragma

--- a/tests/test_log_handler.py
+++ b/tests/test_log_handler.py
@@ -1,0 +1,21 @@
+"""Test log handler."""
+import pathlib
+
+from logging.handlers import RotatingFileHandler
+
+from zippy.utils.log_handler import ZippyFileLogHandler
+
+
+def test_zippy_should_place_log_in_output_log_dir():
+    """Log is always placed in output/logs directory."""
+    handler = ZippyFileLogHandler("test.log")
+    expected_log_path = (
+        pathlib.Path(__file__).parents[1] / "output" / "logs" / "test.log"
+    )
+    assert handler.baseFilename == str(expected_log_path)
+
+
+def test_is_a_rotating_log_handler():
+    """Test that log is rotated to multiple files if it exceeds size."""
+    handler = ZippyFileLogHandler("test.log")
+    assert isinstance(handler, RotatingFileHandler)

--- a/zippy/utils/log_handler.py
+++ b/zippy/utils/log_handler.py
@@ -1,0 +1,12 @@
+"""Custom Log Handler."""
+import pathlib
+
+from logging.handlers import RotatingFileHandler
+
+
+class ZippyFileLogHandler(RotatingFileHandler):
+    """Custom log handler that saves log to output dir even if called from any dir."""
+
+    def __init__(self, filename, *args, **kwargs):
+        log_dir = pathlib.Path(__file__).parents[2] / "output" / "logs"
+        super().__init__(log_dir / filename, *args, **kwargs)


### PR DESCRIPTION
The title says everything.

## Example Usage:
```
    logger = logging.getLogger("client_daemon")
    handler = ZippyFileLogHandler("daemon.log")
    logger.addHandler(handler)
```

And, voila. This will always place the logs in `output/logs` directory.
