### PR TITLE
Apply simple ranking algorithm to Enron dataset

### DIFF
--- a/notebooks/modelling/20190508-divyamani1-simple-priority-ranking-algorithm.ipynb
+++ b/notebooks/modelling/20190508-divyamani1-simple-priority-ranking-algorithm.ipynb
@@ -1,0 +1,1932 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "import nltk\n",
+    "import string, re\n",
+    "from sklearn.feature_extraction.text import CountVectorizer\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time, sys\n",
+    "from IPython.display import clear_output\n",
+    "def update_progress(progress):\n",
+    "    bar_length = 20\n",
+    "    if isinstance(progress, int):\n",
+    "        progress = float(progress)\n",
+    "    if not isinstance(progress, float):\n",
+    "        progress = 0\n",
+    "    if progress < 0:\n",
+    "        progress = 0\n",
+    "    if progress >= 1:\n",
+    "        progress = 1\n",
+    "    block = int(round(bar_length * progress))\n",
+    "    clear_output(wait = True)\n",
+    "    text = \"Progress: [{0}] {1:.1f}%\".format( \"#\" * block + \"-\" * (bar_length - block), progress * 100)\n",
+    "    print(text)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Date</th>\n",
+       "      <th>From</th>\n",
+       "      <th>To</th>\n",
+       "      <th>Subject</th>\n",
+       "      <th>X-From</th>\n",
+       "      <th>X-To</th>\n",
+       "      <th>X-cc</th>\n",
+       "      <th>X-bcc</th>\n",
+       "      <th>X-Folder</th>\n",
+       "      <th>X-Origin</th>\n",
+       "      <th>X-FileName</th>\n",
+       "      <th>content</th>\n",
+       "      <th>user</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Message-ID</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>&lt;18782981.1075855378110.JavaMail.evans@thyme&gt;</th>\n",
+       "      <td>2001-05-14 23:39:00</td>\n",
+       "      <td>(phillip.allen@enron.com)</td>\n",
+       "      <td>(tim.belden@enron.com)</td>\n",
+       "      <td></td>\n",
+       "      <td>Phillip K Allen</td>\n",
+       "      <td>Tim Belden &lt;Tim Belden/Enron@EnronXGate&gt;</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>\\Phillip_Allen_Jan2002_1\\Allen, Phillip K.\\'Se...</td>\n",
+       "      <td>Allen-P</td>\n",
+       "      <td>pallen (Non-Privileged).pst</td>\n",
+       "      <td>Here is our forecast\\n\\n</td>\n",
+       "      <td>allen-p</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>&lt;15464986.1075855378456.JavaMail.evans@thyme&gt;</th>\n",
+       "      <td>2001-05-04 20:51:00</td>\n",
+       "      <td>(phillip.allen@enron.com)</td>\n",
+       "      <td>(john.lavorato@enron.com)</td>\n",
+       "      <td>Re:</td>\n",
+       "      <td>Phillip K Allen</td>\n",
+       "      <td>John J Lavorato &lt;John J Lavorato/ENRON@enronXg...</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>\\Phillip_Allen_Jan2002_1\\Allen, Phillip K.\\'Se...</td>\n",
+       "      <td>Allen-P</td>\n",
+       "      <td>pallen (Non-Privileged).pst</td>\n",
+       "      <td>Traveling to have a business meeting takes the...</td>\n",
+       "      <td>allen-p</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>&lt;24216240.1075855687451.JavaMail.evans@thyme&gt;</th>\n",
+       "      <td>2000-10-18 10:00:00</td>\n",
+       "      <td>(phillip.allen@enron.com)</td>\n",
+       "      <td>(leah.arsdall@enron.com)</td>\n",
+       "      <td>Re: test</td>\n",
+       "      <td>Phillip K Allen</td>\n",
+       "      <td>Leah Van Arsdall</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>\\Phillip_Allen_Dec2000\\Notes Folders\\'sent mail</td>\n",
+       "      <td>Allen-P</td>\n",
+       "      <td>pallen.nsf</td>\n",
+       "      <td>test successful.  way to go!!!</td>\n",
+       "      <td>allen-p</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>&lt;13505866.1075863688222.JavaMail.evans@thyme&gt;</th>\n",
+       "      <td>2000-10-23 13:13:00</td>\n",
+       "      <td>(phillip.allen@enron.com)</td>\n",
+       "      <td>(randall.gay@enron.com)</td>\n",
+       "      <td></td>\n",
+       "      <td>Phillip K Allen</td>\n",
+       "      <td>Randall L Gay</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>\\Phillip_Allen_Dec2000\\Notes Folders\\'sent mail</td>\n",
+       "      <td>Allen-P</td>\n",
+       "      <td>pallen.nsf</td>\n",
+       "      <td>Randy,\\n\\n Can you send me a schedule of the s...</td>\n",
+       "      <td>allen-p</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>&lt;30922949.1075863688243.JavaMail.evans@thyme&gt;</th>\n",
+       "      <td>2000-08-31 12:07:00</td>\n",
+       "      <td>(phillip.allen@enron.com)</td>\n",
+       "      <td>(greg.piper@enron.com)</td>\n",
+       "      <td>Re: Hello</td>\n",
+       "      <td>Phillip K Allen</td>\n",
+       "      <td>Greg Piper</td>\n",
+       "      <td></td>\n",
+       "      <td></td>\n",
+       "      <td>\\Phillip_Allen_Dec2000\\Notes Folders\\'sent mail</td>\n",
+       "      <td>Allen-P</td>\n",
+       "      <td>pallen.nsf</td>\n",
+       "      <td>Let's shoot for Tuesday at 11:45.</td>\n",
+       "      <td>allen-p</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                                             Date  \\\n",
+       "Message-ID                                                          \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme> 2001-05-14 23:39:00   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme> 2001-05-04 20:51:00   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme> 2000-10-18 10:00:00   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme> 2000-10-23 13:13:00   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme> 2000-08-31 12:07:00   \n",
+       "\n",
+       "                                                                    From  \\\n",
+       "Message-ID                                                                 \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>  (phillip.allen@enron.com)   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  (phillip.allen@enron.com)   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>  (phillip.allen@enron.com)   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>  (phillip.allen@enron.com)   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>  (phillip.allen@enron.com)   \n",
+       "\n",
+       "                                                                      To  \\\n",
+       "Message-ID                                                                 \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>     (tim.belden@enron.com)   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  (john.lavorato@enron.com)   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>   (leah.arsdall@enron.com)   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>    (randall.gay@enron.com)   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>     (greg.piper@enron.com)   \n",
+       "\n",
+       "                                                 Subject           X-From  \\\n",
+       "Message-ID                                                                  \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>             Phillip K Allen   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>        Re:  Phillip K Allen   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>   Re: test  Phillip K Allen   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>             Phillip K Allen   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>  Re: Hello  Phillip K Allen   \n",
+       "\n",
+       "                                                                                            X-To  \\\n",
+       "Message-ID                                                                                         \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>           Tim Belden <Tim Belden/Enron@EnronXGate>   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  John J Lavorato <John J Lavorato/ENRON@enronXg...   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>                                   Leah Van Arsdall   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>                                      Randall L Gay   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>                                         Greg Piper   \n",
+       "\n",
+       "                                              X-cc X-bcc  \\\n",
+       "Message-ID                                                 \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>              \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>              \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>              \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>              \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>              \n",
+       "\n",
+       "                                                                                        X-Folder  \\\n",
+       "Message-ID                                                                                         \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>  \\Phillip_Allen_Jan2002_1\\Allen, Phillip K.\\'Se...   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  \\Phillip_Allen_Jan2002_1\\Allen, Phillip K.\\'Se...   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>    \\Phillip_Allen_Dec2000\\Notes Folders\\'sent mail   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>    \\Phillip_Allen_Dec2000\\Notes Folders\\'sent mail   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>    \\Phillip_Allen_Dec2000\\Notes Folders\\'sent mail   \n",
+       "\n",
+       "                                              X-Origin  \\\n",
+       "Message-ID                                               \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>  Allen-P   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  Allen-P   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>  Allen-P   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>  Allen-P   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>  Allen-P   \n",
+       "\n",
+       "                                                                X-FileName  \\\n",
+       "Message-ID                                                                   \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>  pallen (Non-Privileged).pst   \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  pallen (Non-Privileged).pst   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>                   pallen.nsf   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>                   pallen.nsf   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>                   pallen.nsf   \n",
+       "\n",
+       "                                                                                         content  \\\n",
+       "Message-ID                                                                                         \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>                          Here is our forecast\\n\\n    \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  Traveling to have a business meeting takes the...   \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>                     test successful.  way to go!!!   \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>  Randy,\\n\\n Can you send me a schedule of the s...   \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>                Let's shoot for Tuesday at 11:45.     \n",
+       "\n",
+       "                                                  user  \n",
+       "Message-ID                                              \n",
+       "<18782981.1075855378110.JavaMail.evans@thyme>  allen-p  \n",
+       "<15464986.1075855378456.JavaMail.evans@thyme>  allen-p  \n",
+       "<24216240.1075855687451.JavaMail.evans@thyme>  allen-p  \n",
+       "<13505866.1075863688222.JavaMail.evans@thyme>  allen-p  \n",
+       "<30922949.1075863688243.JavaMail.evans@thyme>  allen-p  "
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "data = '../../data/interim/enron-dataset-clean-v1.pkl'\n",
+    "emails = pd.read_pickle(data)\n",
+    "emails.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(517401, 3)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "priority_df = emails.loc[:, ['Date', 'From', 'Subject', 'content']]\n",
+    "priority_df.set_index('Date', inplace=True)\n",
+    "priority_df.sort_index(inplace=True)\n",
+    "priority_df.loc[:, ['Subject', 'content']] = priority_df.loc[:, ['Subject', 'content']].apply(lambda x: x.str.lower())\n",
+    "priority_df.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>From</th>\n",
+       "      <th>Subject</th>\n",
+       "      <th>content</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Date</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1980-01-01</th>\n",
+       "      <td>(outlook.team@enron.com)</td>\n",
+       "      <td>3 - urgent - to prevent loss of information</td>\n",
+       "      <td>critical migration information:\\n\\n1. your sch...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1980-01-01</th>\n",
+       "      <td>(rosalee.fleming@enron.com)</td>\n",
+       "      <td>university of houston reception</td>\n",
+       "      <td>calling all alumni!\\n       \\nuniversity of ho...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1980-01-01</th>\n",
+       "      <td>(tori.wells@enron.com)</td>\n",
+       "      <td>re: update from cousins in missouri</td>\n",
+       "      <td>letter dictated by ken lay\\n\\n\\n\\nhello janice...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1980-01-01</th>\n",
+       "      <td>(rosalee.fleming@enron.com)</td>\n",
+       "      <td>re: energy tf final report</td>\n",
+       "      <td>mr. sikes -\\n\\nkenneth l. lay is the chairman ...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1980-01-01</th>\n",
+       "      <td>(kay.mann@enron.com)</td>\n",
+       "      <td>re: bluedog change order #2, rev 4</td>\n",
+       "      <td>hi brian,\\n\\nhere are my observations/question...</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                   From  \\\n",
+       "Date                                      \n",
+       "1980-01-01     (outlook.team@enron.com)   \n",
+       "1980-01-01  (rosalee.fleming@enron.com)   \n",
+       "1980-01-01       (tori.wells@enron.com)   \n",
+       "1980-01-01  (rosalee.fleming@enron.com)   \n",
+       "1980-01-01         (kay.mann@enron.com)   \n",
+       "\n",
+       "                                                Subject  \\\n",
+       "Date                                                      \n",
+       "1980-01-01  3 - urgent - to prevent loss of information   \n",
+       "1980-01-01              university of houston reception   \n",
+       "1980-01-01          re: update from cousins in missouri   \n",
+       "1980-01-01                   re: energy tf final report   \n",
+       "1980-01-01           re: bluedog change order #2, rev 4   \n",
+       "\n",
+       "                                                      content  \n",
+       "Date                                                           \n",
+       "1980-01-01  critical migration information:\\n\\n1. your sch...  \n",
+       "1980-01-01  calling all alumni!\\n       \\nuniversity of ho...  \n",
+       "1980-01-01  letter dictated by ken lay\\n\\n\\n\\nhello janice...  \n",
+       "1980-01-01  mr. sikes -\\n\\nkenneth l. lay is the chairman ...  \n",
+       "1980-01-01  hi brian,\\n\\nhere are my observations/question...  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "priority_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Subject</th>\n",
+       "      <th>content</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>From</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>(kay.mann@enron.com)</th>\n",
+       "      <td>16735</td>\n",
+       "      <td>16735</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(vince.kaminski@enron.com)</th>\n",
+       "      <td>14368</td>\n",
+       "      <td>14368</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(jeff.dasovich@enron.com)</th>\n",
+       "      <td>11411</td>\n",
+       "      <td>11411</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(pete.davis@enron.com)</th>\n",
+       "      <td>9149</td>\n",
+       "      <td>9149</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>(chris.germany@enron.com)</th>\n",
+       "      <td>8801</td>\n",
+       "      <td>8801</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                            Subject  content\n",
+       "From                                        \n",
+       "(kay.mann@enron.com)          16735    16735\n",
+       "(vince.kaminski@enron.com)    14368    14368\n",
+       "(jeff.dasovich@enron.com)     11411    11411\n",
+       "(pete.davis@enron.com)         9149     9149\n",
+       "(chris.germany@enron.com)      8801     8801"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "priority_df.groupby('From').aggregate('count').sort_values('Subject', ascending=False).head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "(465660, 3)\n",
+      "(51741, 3)\n"
+     ]
+    }
+   ],
+   "source": [
+    "priority_train = priority_df.iloc[:int(priority_df.shape[0]*0.9)]\n",
+    "priority_test = priority_df.iloc[int(priority_df.shape[0]*0.9):]\n",
+    "print(priority_train.shape)\n",
+    "print(priority_test.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from_weight = priority_train.groupby('From', as_index=False).Subject.count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>From</th>\n",
+       "      <th>weight</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>10742</th>\n",
+       "      <td>(kay.mann@enron.com)</td>\n",
+       "      <td>9.712872</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10733</th>\n",
+       "      <td>(vince.kaminski@enron.com)</td>\n",
+       "      <td>9.572828</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10732</th>\n",
+       "      <td>(jeff.dasovich@enron.com)</td>\n",
+       "      <td>9.330254</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10703</th>\n",
+       "      <td>(enron.announcements@enron.com)</td>\n",
+       "      <td>9.058121</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10718</th>\n",
+       "      <td>(sara.shackleton@enron.com)</td>\n",
+       "      <td>9.044758</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                                  From    weight\n",
+       "10742             (kay.mann@enron.com)  9.712872\n",
+       "10733       (vince.kaminski@enron.com)  9.572828\n",
+       "10732        (jeff.dasovich@enron.com)  9.330254\n",
+       "10703  (enron.announcements@enron.com)  9.058121\n",
+       "10718      (sara.shackleton@enron.com)  9.044758"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from_weight['weight'] = from_weight.Subject.apply(lambda x: np.log(x+1))\n",
+    "from_weight.drop('Subject', axis=1, inplace=True)\n",
+    "from_weight.sort_values('weight', ascending=False).head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "is_thread = priority_train.Subject.str.contains('re: ')\n",
+    "threads = priority_train[is_thread]\n",
+    "re_subject_split = threads.Subject.str.strip('re:')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_matrix = pd.concat((threads['From'], re_subject_split), axis=1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_matrix.reset_index(inplace=True, drop=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>From</th>\n",
+       "      <th>Subject</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>(tori.wells@enron.com)</td>\n",
+       "      <td>update from cousins in missouri</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>(rosalee.fleming@enron.com)</td>\n",
+       "      <td>energy tf final report</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>(kay.mann@enron.com)</td>\n",
+       "      <td>bluedog change order #2, rev 4</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>(susan.scott@enron.com)</td>\n",
+       "      <td>erms traders in enpow</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>(sherri.sera@enron.com)</td>\n",
+       "      <td>your not</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                          From                           Subject\n",
+       "0       (tori.wells@enron.com)   update from cousins in missouri\n",
+       "1  (rosalee.fleming@enron.com)            energy tf final report\n",
+       "2         (kay.mann@enron.com)    bluedog change order #2, rev 4\n",
+       "3      (susan.scott@enron.com)             erms traders in enpow\n",
+       "4      (sherri.sera@enron.com)                          your not"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thread_matrix.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_senders = thread_matrix.iloc[:, 0]\n",
+    "senders_freq = thread_senders.groupby(thread_senders).count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "senders_dict = {\n",
+    "    'From': senders_freq.index.tolist(),\n",
+    "    'freq': list(senders_freq.values),\n",
+    "    'weight': list(senders_freq.transform(lambda x: np.log(x+1)))\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "senders_weight = pd.DataFrame(senders_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>From</th>\n",
+       "      <th>freq</th>\n",
+       "      <th>weight</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>(tori.wells@enron.com)</td>\n",
+       "      <td>27</td>\n",
+       "      <td>3.332205</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>(lys@a-klaw.com)</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.098612</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>(geresj@tdusa.com)</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.693147</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>(lga@mother.com)</td>\n",
+       "      <td>2</td>\n",
+       "      <td>1.098612</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>(jeff_walker@i2.com)</td>\n",
+       "      <td>4</td>\n",
+       "      <td>1.609438</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                     From  freq    weight\n",
+       "0  (tori.wells@enron.com)    27  3.332205\n",
+       "1        (lys@a-klaw.com)     2  1.098612\n",
+       "2      (geresj@tdusa.com)     1  0.693147\n",
+       "3        (lga@mother.com)     2  1.098612\n",
+       "4    (jeff_walker@i2.com)     4  1.609438"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "senders_weight.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_subs = thread_matrix.iloc[:, 1].unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_counts = {\n",
+    "    'freq': [],\n",
+    "    'time_span': [],\n",
+    "    'weight': []\n",
+    "}\n",
+    "\n",
+    "for thread in thread_subs:\n",
+    "    thread_times = priority_train.index[priority_train.Subject.str.contains(thread, regex=False) | priority_train.Subject.str.contains('re: ' + thread, regex=False)]\n",
+    "    thread_freq = len(thread_times)\n",
+    "    min_time = thread_times.min()\n",
+    "    max_time = thread_times.max()\n",
+    "    time_span = (max_time - min_time).seconds\n",
+    "    if thread_freq<2:\n",
+    "        thread_counts['freq'].append(np.nan)\n",
+    "        thread_counts['time_span'].append(np.nan)\n",
+    "        thread_counts['weight'].append(np.nan)\n",
+    "    else:\n",
+    "        try:\n",
+    "            weight = thread_freq / time_span\n",
+    "            log_weight = 10 + np.log10(weight)\n",
+    "        except ZeroDivisionError:\n",
+    "            log_weight = np.mean(thread_counts['weight'])\n",
+    "        thread_counts['freq'].append(thread_freq)\n",
+    "        thread_counts['time_span'].append(time_span)\n",
+    "        thread_counts['weight'].append(log_weight)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_weights = pd.DataFrame(thread_counts)\n",
+    "thread_weights.dropna(inplace=True)\n",
+    "thread_weights['thread'] = thread_matrix.iloc[:, 1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>freq</th>\n",
+       "      <th>time_span</th>\n",
+       "      <th>weight</th>\n",
+       "      <th>thread</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>60300.0</td>\n",
+       "      <td>5.821743</td>\n",
+       "      <td>update from cousins in missouri</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>4.0</td>\n",
+       "      <td>61920.0</td>\n",
+       "      <td>5.810229</td>\n",
+       "      <td>energy tf final report</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>7.0</td>\n",
+       "      <td>25080.0</td>\n",
+       "      <td>6.445771</td>\n",
+       "      <td>your not</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>11.0</td>\n",
+       "      <td>66389.0</td>\n",
+       "      <td>6.219297</td>\n",
+       "      <td>perd</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>12.0</td>\n",
+       "      <td>33540.0</td>\n",
+       "      <td>6.553618</td>\n",
+       "      <td>ge releas</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   freq  time_span    weight                            thread\n",
+       "0   4.0    60300.0  5.821743   update from cousins in missouri\n",
+       "1   4.0    61920.0  5.810229            energy tf final report\n",
+       "2   7.0    25080.0  6.445771                          your not\n",
+       "3  11.0    66389.0  6.219297                              perd\n",
+       "4  12.0    33540.0  6.553618                         ge releas"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thread_weights.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vec = CountVectorizer(stop_words=nltk.corpus.stopwords.words('english'))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_tdm = vec.fit_transform(thread_weights.thread)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_tdm = pd.DataFrame(thread_tdm.toarray(), columns=vec.get_feature_names())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "term_weights = []\n",
+    "for term in thread_tdm.columns:\n",
+    "    weight = thread_weights.weight[thread_weights.thread.str.contains(term, regex=False)].mean()\n",
+    "    term_weights.append(weight)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "thread_term_weights = pd.DataFrame.from_dict({\n",
+    "    'term': thread_tdm.columns,\n",
+    "    'weight': term_weights\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>term</th>\n",
+       "      <th>weight</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>251</th>\n",
+       "      <td>646</td>\n",
+       "      <td>10.957523</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>185</th>\n",
+       "      <td>3483</td>\n",
+       "      <td>10.957523</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4055</th>\n",
+       "      <td>parpak</td>\n",
+       "      <td>10.483675</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2877</th>\n",
+       "      <td>informed</td>\n",
+       "      <td>10.171952</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2569</th>\n",
+       "      <td>graphics</td>\n",
+       "      <td>9.176091</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          term     weight\n",
+       "251        646  10.957523\n",
+       "185       3483  10.957523\n",
+       "4055    parpak  10.483675\n",
+       "2877  informed  10.171952\n",
+       "2569  graphics   9.176091"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "thread_term_weights.sort_values('weight', ascending=False).head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "priority_train.content = priority_train.content.str.replace('[^\\w\\s]','', regex=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "priority_train.content = priority_train.content.str.replace('\\b\\d+\\b', '', regex=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "vec = CountVectorizer(stop_words=nltk.corpus.stopwords.words('english'), min_df=10 )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msg_tdm = vec.fit_transform(priority_train.content)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msg_tdm = pd.SparseDataFrame(msg_tdm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msg_tdm.columns = vec.get_feature_names()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msg_terms = pd.DataFrame.from_dict({\n",
+    "    'term': vec.get_feature_names(),\n",
+    "    'freq': list(msg_tdm.sum())\n",
+    "})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "msg_terms['weight'] = msg_terms.freq.apply(lambda x: np.log(x))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>freq</th>\n",
+       "      <th>term</th>\n",
+       "      <th>weight</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>21802</th>\n",
+       "      <td>16.0</td>\n",
+       "      <td>720300</td>\n",
+       "      <td>2.772589</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>24107</th>\n",
+       "      <td>10.0</td>\n",
+       "      <td>9164410496</td>\n",
+       "      <td>2.302585</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>21924</th>\n",
+       "      <td>191.0</td>\n",
+       "      <td>732</td>\n",
+       "      <td>5.252273</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>29932</th>\n",
+       "      <td>3829.0</td>\n",
+       "      <td>apologize</td>\n",
+       "      <td>8.250359</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8281</th>\n",
+       "      <td>22.0</td>\n",
+       "      <td>17times</td>\n",
+       "      <td>3.091042</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         freq        term    weight\n",
+       "21802    16.0      720300  2.772589\n",
+       "24107    10.0  9164410496  2.302585\n",
+       "21924   191.0         732  5.252273\n",
+       "29932  3829.0   apologize  8.250359\n",
+       "8281     22.0     17times  3.091042"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "msg_terms.iloc[np.random.randint(0, 40000, size=(5, )), :]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_weights(search_term, weight_df, term=True):\n",
+    "    search_term = str(search_term)\n",
+    "    if (len(search_term)>0):\n",
+    "        if term:\n",
+    "            term_match = False\n",
+    "            for search_item in search_term:\n",
+    "                match = weight_df.term.str.contains(search_item, regex=False)\n",
+    "                term_match = term_match | match\n",
+    "        else:\n",
+    "            term_match = weight_df.thread.str.contains(search_term, regex=False)\n",
+    "        \n",
+    "        match_weights = weight_df.weight[term_match]\n",
+    "        if len(match_weights)<1:\n",
+    "            return 1\n",
+    "        else:\n",
+    "            return match_weights.mean()\n",
+    "    else:\n",
+    "        return 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def rank_message(msg):\n",
+    "    # First, using the from weights\n",
+    "    from_wt = from_weight[from_weight['From']==msg['From']]\n",
+    "    if len(from_wt)>0:\n",
+    "        msg_from_wt = from_wt.weight\n",
+    "    else:\n",
+    "        msg_from_wt = 1\n",
+    "    \n",
+    "    # Second, using senders weights from threads\n",
+    "    senders_wt = senders_weight[senders_weight['From']==msg['From']]\n",
+    "    if len(senders_wt)>0:\n",
+    "        msg_thread_from_wt = senders_wt.weight\n",
+    "    else:\n",
+    "        msg_thread_from_wt = 1\n",
+    "        \n",
+    "    # Then, from thread activity\n",
+    "    is_thread = len(msg.Subject.split('re: ')) > 1\n",
+    "    if is_thread:\n",
+    "        subject = msg.Subject.split('re: ')[1]\n",
+    "        msg_thread_activity_wt = get_weights(subject, thread_weights, term=False)\n",
+    "    else:\n",
+    "        msg_thread_activity_wt = 1\n",
+    "        \n",
+    "    # Then, weights based on terms in threads\n",
+    "    try:\n",
+    "        sub_vec = vec.fit_transform([msg['Subject']])\n",
+    "        msg_thread_terms = vec.get_feature_names()\n",
+    "        msg_thread_term_wt = get_weights(msg_thread_terms, thread_term_weights)\n",
+    "    except:\n",
+    "        # Some subjects from the test set result in empty vocabulary\n",
+    "        msg_thread_term_wt = 1\n",
+    "    \n",
+    "    # Then, weights based on terms in message\n",
+    "    try:\n",
+    "        msg_vec = vec.fit_transform([msg['content']])\n",
+    "        msg_terms = vec.get_feature_names()\n",
+    "        msg_terms_wt = get_weights(msg_terms, msg_term_weights)\n",
+    "    except:\n",
+    "        # Some subjects from the test set result in empty vocabulary\n",
+    "        msg_terms_wt = 1\n",
+    "    \n",
+    "    # Calculating Rank\n",
+    "    rank = float(msg_from_wt) * float(msg_thread_from_wt) * float(msg_thread_activity_wt) * float(msg_thread_term_wt) * float(msg_terms_wt)\n",
+    "    \n",
+    "    return [msg.name, msg['From'], msg['Subject'], rank]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Progress: [####################] 100.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "rank_dict = {\n",
+    "    'date': [],\n",
+    "    'from': [],\n",
+    "    'subject': [],\n",
+    "    'rank': []\n",
+    "}\n",
+    "\n",
+    "for i in range(priority_train.shape[0]):\n",
+    "    result = rank_message(priority_train.iloc[i, :])\n",
+    "    rank_dict['date'].append(result[0])\n",
+    "    rank_dict['from'].append(result[1])\n",
+    "    rank_dict['subject'].append(result[2])\n",
+    "    rank_dict['rank'].append(result[3])\n",
+    "    update_progress(i/priority_train.shape[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rank_df = pd.DataFrame.from_dict(rank_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "170.61861518695991\n"
+     ]
+    }
+   ],
+   "source": [
+    "priority_threshold = rank_df['rank'].median()\n",
+    "print(priority_threshold)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rank_df['priority'] = rank_df['rank']>priority_threshold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>from</th>\n",
+       "      <th>rank</th>\n",
+       "      <th>subject</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(outlook.team@enron.com)</td>\n",
+       "      <td>179.459524</td>\n",
+       "      <td>3 - urgent - to prevent loss of information</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(rosalee.fleming@enron.com)</td>\n",
+       "      <td>310.673189</td>\n",
+       "      <td>university of houston reception</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(tori.wells@enron.com)</td>\n",
+       "      <td>594.246703</td>\n",
+       "      <td>re: update from cousins in missouri</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(rosalee.fleming@enron.com)</td>\n",
+       "      <td>1804.662818</td>\n",
+       "      <td>re: energy tf final report</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(kay.mann@enron.com)</td>\n",
+       "      <td>590.674601</td>\n",
+       "      <td>re: bluedog change order #2, rev 4</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        date                         from         rank  \\\n",
+       "0 1980-01-01     (outlook.team@enron.com)   179.459524   \n",
+       "1 1980-01-01  (rosalee.fleming@enron.com)   310.673189   \n",
+       "2 1980-01-01       (tori.wells@enron.com)   594.246703   \n",
+       "3 1980-01-01  (rosalee.fleming@enron.com)  1804.662818   \n",
+       "4 1980-01-01         (kay.mann@enron.com)   590.674601   \n",
+       "\n",
+       "                                       subject  \n",
+       "0  3 - urgent - to prevent loss of information  \n",
+       "1              university of houston reception  \n",
+       "2          re: update from cousins in missouri  \n",
+       "3                   re: energy tf final report  \n",
+       "4           re: bluedog change order #2, rev 4  "
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rank_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>from</th>\n",
+       "      <th>rank</th>\n",
+       "      <th>subject</th>\n",
+       "      <th>priority</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(john.griffith@enron.com)</td>\n",
+       "      <td>154.973708</td>\n",
+       "      <td>don't forget to register!</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(john.griffith@enron.com)</td>\n",
+       "      <td>154.973708</td>\n",
+       "      <td>don't forget to register!</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(doug.gilbert-smith@enron.com)</td>\n",
+       "      <td>56.325155</td>\n",
+       "      <td>send in your registration card</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>13</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(phillip.allen@enron.com)</td>\n",
+       "      <td>50.406585</td>\n",
+       "      <td></td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>20</th>\n",
+       "      <td>1980-01-01</td>\n",
+       "      <td>(don.baughman@enron.com)</td>\n",
+       "      <td>107.951010</td>\n",
+       "      <td>supplies for sailing trip jan. 27</td>\n",
+       "      <td>False</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         date                            from        rank  \\\n",
+       "5  1980-01-01       (john.griffith@enron.com)  154.973708   \n",
+       "9  1980-01-01       (john.griffith@enron.com)  154.973708   \n",
+       "12 1980-01-01  (doug.gilbert-smith@enron.com)   56.325155   \n",
+       "13 1980-01-01       (phillip.allen@enron.com)   50.406585   \n",
+       "20 1980-01-01        (don.baughman@enron.com)  107.951010   \n",
+       "\n",
+       "                              subject  priority  \n",
+       "5           don't forget to register!     False  \n",
+       "9           don't forget to register!     False  \n",
+       "12     send in your registration card     False  \n",
+       "13                                        False  \n",
+       "20  supplies for sailing trip jan. 27     False  "
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "rank_df[~rank_df['priority']].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7f1c688167b8>"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZ0AAAD8CAYAAACsAHnpAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAGGJJREFUeJzt3X/QnWV95/H3R0IRFTCBNJsGbHBJ3QW2oqQRR+taGUmq\nW8Ed0Di7JbPLQmdguzp1Zgu2U6wMO7BjpaWtjChZflSFFH+QVVkmgFunM4XwoCgEyCYKLolAUkKJ\nuooGv/vHuR45ecyPkx/nPnlO3q+ZM+c63/u+7nNdkDyf3Pe5nvukqpAkqQsvGfUAJEkHD0NHktQZ\nQ0eS1BlDR5LUGUNHktQZQ0eS1BlDR5LUGUNHktQZQ0eS1JkZox7AgeKYY46p+fPnj3oYkjSt3H//\n/f9YVbMH3d/QaebPn8/ExMSohyFJ00qS7+7J/l5ekyR1xtCRJHXG0JEkdcbQkSR1xtCRJHVmaKGT\n5KVJVif5ZpI1Sf601WclWZVkXXue2dfnkiTrk6xNsrivfmqSB9u2q5Ok1Q9Lckur35tkfl+fZe09\n1iVZNqx5SpIGN8wzneeBt1XVa4FTgCVJTgMuBu6qqgXAXe01SU4ElgInAUuAjyc5pB3rGuB8YEF7\nLGn184Bnq+oE4CrgynasWcClwBuARcCl/eEmSRqNoYVO9fygvTy0PQo4E7ih1W8AzmrtM4Gbq+r5\nqnoMWA8sSjIXOLKq7qned2vfOKXP5LFuBU5vZ0GLgVVVtaWqngVW8WJQSZJGZKif6SQ5JMkDwCZ6\nIXAvMKeqnmy7PAXMae15wBN93Te02rzWnlrfrk9VbQOeA47exbGmju+CJBNJJjZv3rzX85QkDWao\ndySoqheAU5K8EvhCkpOnbK8kNcwx7EpVXQtcC7Bw4cJ9Gsf8i7+8130fv+Kd+/LWkjRtdLJ6rar+\nCfgqvUtcT7dLZrTnTW23jcBxfd2ObbWNrT21vl2fJDOAo4BndnEsSdIIDXP12ux2hkOSw4G3A48C\nK4HJ1WTLgNtaeyWwtK1IO57egoHV7VLc1iSntc9rzp3SZ/JYZwN3t8997gDOSDKzLSA4o9UkSSM0\nzMtrc4Eb2gq0lwArqupLSf4BWJHkPOC7wHsAqmpNkhXAw8A24KJ2eQ7gQuB64HDg9vYAuA64Kcl6\nYAu91W9U1ZYklwH3tf0+UlVbhjhXSdIAhhY6VfUt4HU7qD8DnL6TPpcDl++gPgGcvIP6j4FzdnKs\n5cDyPRu1JGmYvCOBJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aO\nJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSp\nM4aOJKkzho4kqTOGjiSpM4aOJKkzQwudJMcl+WqSh5OsSfL+Vv9wko1JHmiPd/T1uSTJ+iRrkyzu\nq5+a5MG27eokafXDktzS6vcmmd/XZ1mSde2xbFjzlCQNbsYQj70N+GBVfT3JEcD9SVa1bVdV1Uf7\nd05yIrAUOAn4FeDOJL9WVS8A1wDnA/cCXwGWALcD5wHPVtUJSZYCVwLvTTILuBRYCFR775VV9ewQ\n5ytJ2o2hnelU1ZNV9fXW/j7wCDBvF13OBG6uquer6jFgPbAoyVzgyKq6p6oKuBE4q6/PDa19K3B6\nOwtaDKyqqi0taFbRCypJ0gh18plOu+z1OnpnKgC/n+RbSZYnmdlq84An+rptaLV5rT21vl2fqtoG\nPAccvYtjSZJGaOihk+QVwOeAD1TVVnqXyl4NnAI8CfzZsMewi7FdkGQiycTmzZtHNQxJOmgMNXSS\nHEovcD5dVZ8HqKqnq+qFqvoZ8ElgUdt9I3BcX/djW21ja0+tb9cnyQzgKOCZXRxrO1V1bVUtrKqF\ns2fP3pepSpIGMMzVawGuAx6pqo/11ef27fZu4KHWXgksbSvSjgcWAKur6klga5LT2jHPBW7r6zO5\nMu1s4O72uc8dwBlJZrbLd2e0miRphIa5eu1NwO8CDyZ5oNU+BLwvySn0VpU9DvweQFWtSbICeJje\nyreL2so1gAuB64HD6a1au73VrwNuSrIe2EJv9RtVtSXJZcB9bb+PVNWWIc1TkjSgoYVOVf09kB1s\n+sou+lwOXL6D+gRw8g7qPwbO2cmxlgPLBx2vJGn4vCOBJKkzho4kqTOGjiSpM4aOJKkzho4kqTOG\njiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4k\nqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTOGjiSpM4aOJKkzho4kqTNDC50kxyX5apKH\nk6xJ8v5Wn5VkVZJ17XlmX59LkqxPsjbJ4r76qUkebNuuTpJWPyzJLa1+b5L5fX2WtfdYl2TZsOYp\nSRrcMM90tgEfrKoTgdOAi5KcCFwM3FVVC4C72mvatqXAScAS4ONJDmnHugY4H1jQHkta/Tzg2ao6\nAbgKuLIdaxZwKfAGYBFwaX+4SZJGY2ihU1VPVtXXW/v7wCPAPOBM4Ia22w3AWa19JnBzVT1fVY8B\n64FFSeYCR1bVPVVVwI1T+kwe61bg9HYWtBhYVVVbqupZYBUvBpUkaUQ6+UynXfZ6HXAvMKeqnmyb\nngLmtPY84Im+bhtabV5rT61v16eqtgHPAUfv4lhTx3VBkokkE5s3b97L2UmSBjX00EnyCuBzwAeq\namv/tnbmUsMew85U1bVVtbCqFs6ePXtUw5Ckg8ZQQyfJofQC59NV9flWfrpdMqM9b2r1jcBxfd2P\nbbWNrT21vl2fJDOAo4BndnEsSdIIDXP1WoDrgEeq6mN9m1YCk6vJlgG39dWXthVpx9NbMLC6XYrb\nmuS0dsxzp/SZPNbZwN3t7OkO4IwkM9sCgjNaTZI0QjOGeOw3Ab8LPJjkgVb7EHAFsCLJecB3gfcA\nVNWaJCuAh+mtfLuoql5o/S4ErgcOB25vD+iF2k1J1gNb6K1+o6q2JLkMuK/t95Gq2jKsiUqSBjO0\n0Kmqvweyk82n76TP5cDlO6hPACfvoP5j4JydHGs5sHzQ8UqShm+gy2tJ/tWwByJJGn+Dfqbz8SSr\nk1yY5KihjkiSNLYGCp2q+k3g39FbEXZ/ks8keftQRyZJGjsDr16rqnXAHwN/CPxr4Ookjyb5t8Ma\nnCRpvAz6mc6vJ7mK3q1s3gb8TlX9y9a+aojjkySNkUFXr/0l8CngQ1X1o8liVX0vyR8PZWSSpLEz\naOi8E/jR5O/NJHkJ8NKq+n9VddPQRidJGiuDfqZzJ71fzJz0slaTJGlgg4bOS6vqB5MvWvtlwxmS\nJGlcDRo6P0zy+skXSU4FfrSL/SVJ+gWDfqbzAeBvk3yP3q1t/hnw3qGNSpI0lgYKnaq6L8m/AF7T\nSmur6qfDG5YkaRztyQ0/fwOY3/q8PglVdeNQRiVJGksDhU6Sm4B/DjwATH7dQAGGjiRpYIOe6SwE\nTmxfkCZJ0l4ZdPXaQ/QWD0iStNcGPdM5Bng4yWrg+cliVb1rKKOSJI2lQUPnw8MchCTp4DDokum/\nS/KrwIKqujPJy4BDhjs0SdK4GfSrDc4HbgU+0UrzgC8Oa1CSpPE06EKCi4A3AVvh51/o9svDGpQk\naTwNGjrPV9VPJl8kmUHv93QkSRrYoKHzd0k+BBye5O3A3wL/c3jDkiSNo0FD52JgM/Ag8HvAVwC/\nMVSStEcGXb32M+CT7SFJ0l4ZdPXaY0m+M/Wxmz7Lk2xK8lBf7cNJNiZ5oD3e0bftkiTrk6xNsriv\nfmqSB9u2q5Ok1Q9Lckur35tkfl+fZUnWtceywf9zSJKGaU/uvTbppcA5wKzd9Lke+Ct+8aagV1XV\nR/sLSU4ElgInAb8C3Jnk16rqBeAa4HzgXnqX9ZYAtwPnAc9W1QlJlgJXAu9NMgu4tI25gPuTrKyq\nZwecqyRpSAY606mqZ/oeG6vqz4F37qbP14AtA47jTODmqnq+qh4D1gOLkswFjqyqe9rNRm8Ezurr\nc0Nr3wqc3s6CFgOrqmpLC5pV9IJKkjRig361wev7Xr6E3lnEnnwXT7/fT3IuMAF8sAXDPOCevn02\ntNpPW3tqnfb8BEBVbUvyHHB0f30HfSRJIzRocPxZX3sb8Djwnr14v2uAy+hd9rqsHfc/7sVx9osk\nFwAXALzqVa8a1TAk6aAx6Oq139ofb1ZVT0+2k3wS+FJ7uRE4rm/XY1ttY2tPrff32dB+WfUo4JlW\nf+uUPv97J+O5FrgWYOHChf6yqyQN2aCX1/5gV9ur6mMDHmduVT3ZXr6b3vf0AKwEPpPkY/QWEiwA\nVlfVC0m2JjmN3kKCc4G/7OuzDPgH4Gzg7qqqJHcA/y3JzLbfGcAlg4xPkjRce7J67Tfo/aAH+B1g\nNbBuZx2SfJbeGccxSTbQW1H21iSn0Lu89ji9XzSlqtYkWQE8TO/y3UVt5RrAhfRWwh1Ob9Xa7a1+\nHXBTkvX0FiwsbcfakuQy4L6230eqatAFDZKkIcog30Cd5GvAO6vq++31EcCXq+otQx5fZxYuXFgT\nExN73X/+xV/e676PX7HLhYCSdMBKcn9VLdz9nj2D3gZnDvCTvtc/aTVJkgY26OW1G4HVSb7QXp/F\ni78jI0nSQAZdvXZ5ktuB32yl/1BV3xjesCRJ42jQy2sALwO2VtVf0FumfPyQxiRJGlOD3vDzUuAP\neXHp8aHA3wxrUJKk8TTomc67gXcBPwSoqu8BRwxrUJKk8TRo6Pyk3XCzAJK8fHhDkiSNq0FDZ0WS\nTwCvTHI+cCd+oZskaQ8Nunrto0neDmwFXgP8SVWtGurIJEljZ7ehk+QQ4M5200+DRpK013Z7ea3d\nA+1nSY7qYDySpDE26B0JfgA8mGQVbQUbQFX9l6GMSpI0lgYNnc+3hyRJe22XoZPkVVX1f6vK+6xJ\nkvbZ7j7T+eJkI8nnhjwWSdKY213opK/96mEORJI0/nYXOrWTtiRJe2x3Cwlem2QrvTOew1ub9rqq\n6sihjk6SNFZ2GTpVdUhXAzmY+VXXkg4We/J9OpIk7RNDR5LUGUNHktQZQ0eS1BlDR5LUGUNHktQZ\nQ0eS1JmhhU6S5Uk2JXmorzYryaok69rzzL5tlyRZn2RtksV99VOTPNi2XZ0krX5Yklta/d4k8/v6\nLGvvsS7JsmHNUZK0Z4Z5pnM9sGRK7WLgrqpaANzVXpPkRGApcFLr8/H2jaUA1wDnAwvaY/KY5wHP\nVtUJwFXAle1Ys4BLgTcAi4BL+8NNkjQ6QwudqvoasGVK+Uxg8msSbgDO6qvfXFXPV9VjwHpgUZK5\nwJFVdU9VFXDjlD6Tx7oVOL2dBS0GVlXVlqp6lt5XbE8NP0nSCHT9mc6cqnqytZ8C5rT2POCJvv02\ntNq81p5a365PVW0DngOO3sWxJEkjNrKFBO3MZaR3rk5yQZKJJBObN28e5VAk6aDQdeg83S6Z0Z43\ntfpG4Li+/Y5ttY2tPbW+XZ8kM4CjgGd2caxfUFXXVtXCqlo4e/bsfZiWJGkQXYfOSmByNdky4La+\n+tK2Iu14egsGVrdLcVuTnNY+rzl3Sp/JY50N3N3Onu4Azkgysy0gOKPVJEkjtrvv09lrST4LvBU4\nJskGeivKrgBWJDkP+C7wHoCqWpNkBfAwsA24qKpeaIe6kN5KuMOB29sD4DrgpiTr6S1YWNqOtSXJ\nZcB9bb+PVNXUBQ2SpBEYWuhU1ft2sun0nex/OXD5DuoTwMk7qP8YOGcnx1oOLB94sJKkTnhHAklS\nZwwdSVJnDB1JUmcMHUlSZwwdSVJnDB1JUmcMHUlSZwwdSVJnDB1JUmcMHUlSZwwdSVJnDB1JUmcM\nHUlSZwwdSVJnDB1JUmcMHUlSZwwdSVJnDB1JUmcMHUlSZwwdSVJnDB1JUmcMHUlSZwwdSVJnDB1J\nUmcMHUlSZwwdSVJnRhI6SR5P8mCSB5JMtNqsJKuSrGvPM/v2vyTJ+iRrkyzuq5/ajrM+ydVJ0uqH\nJbml1e9NMr/rOUqSftEoz3R+q6pOqaqF7fXFwF1VtQC4q70myYnAUuAkYAnw8SSHtD7XAOcDC9pj\nSaufBzxbVScAVwFXdjAfSdJuHEiX184EbmjtG4Cz+uo3V9XzVfUYsB5YlGQucGRV3VNVBdw4pc/k\nsW4FTp88C5Ikjc6oQqeAO5Pcn+SCVptTVU+29lPAnNaeBzzR13dDq81r7an17fpU1TbgOeDoqYNI\nckGSiSQTmzdv3vdZSZJ2acaI3vfNVbUxyS8Dq5I82r+xqipJDXsQVXUtcC3AwoULh/5+knSwG8mZ\nTlVtbM+bgC8Ai4Cn2yUz2vOmtvtG4Li+7se22sbWnlrfrk+SGcBRwDPDmIskaXCdh06Slyc5YrIN\nnAE8BKwElrXdlgG3tfZKYGlbkXY8vQUDq9uluK1JTmuf15w7pc/ksc4G7m6f+0iSRmgUl9fmAF9o\nn+vPAD5TVf8ryX3AiiTnAd8F3gNQVWuSrAAeBrYBF1XVC+1YFwLXA4cDt7cHwHXATUnWA1vorX6T\nJI1Y56FTVd8BXruD+jPA6Tvpczlw+Q7qE8DJO6j/GDhnnwcrSdqvDqQl05KkMWfoSJI6Y+hIkjpj\n6EiSOmPoSJI6Y+hIkjpj6EiSOmPoSJI6Y+hIkjpj6EiSOmPoSJI6Y+hIkjpj6EiSOmPoSJI6Y+hI\nkjpj6EiSOmPoSJI6Y+hIkjrT+ddVa/+af/GX97rv41e8cz+ORJJ2zzMdSVJnDB1JUmcMHUlSZwwd\nSVJnDB1JUmcMHUlSZ8Z6yXSSJcBfAIcAn6qqK0Y8JB3EXN4ujXHoJDkE+Gvg7cAG4L4kK6vq4dGO\nTNPVvoTGKN/bwNKBZGxDB1gErK+q7wAkuRk4EzB0mn39ITqqH2aj/OE/HU3X/16G5Xga59CZBzzR\n93oD8IYRjWUsTdcfZpoePLsbT+McOruV5ALggvbyB0nW7sPhjgH+cd9HdcBwPgeucZoLDGE+uXJ/\nHm2PHWz/f351Tw42zqGzETiu7/WxrfZzVXUtcO3+eLMkE1W1cH8c60DgfA5c4zQXcD4Huv09n3Fe\nMn0fsCDJ8Ul+CVgKrBzxmCTpoDa2ZzpVtS3JfwbuoLdkenlVrRnxsCTpoDa2oQNQVV8BvtLR2+2X\ny3QHEOdz4BqnuYDzOdDt1/mkqvbn8SRJ2qlx/kxHknSAMXT2UZIlSdYmWZ/k4lGPZ2eSLE+yKclD\nfbVZSVYlWdeeZ/Ztu6TNaW2SxX31U5M82LZdnSRdz6WN47gkX03ycJI1Sd4/XeeU5KVJVif5ZpvL\nn07XufRLckiSbyT5Uns9beeT5PE2jgeSTIzBfF6Z5NYkjyZ5JMkbO5tPVfnYywe9BQrfBl4N/BLw\nTeDEUY9rJ2N9C/B64KG+2n8HLm7ti4ErW/vENpfDgOPbHA9p21YDpwEBbgd+e0TzmQu8vrWPAP5P\nG/e0m1N731e09qHAvW08024uU+b1B8BngC+NwZ+3x4FjptSm83xuAP5Ta/8S8Mqu5jOSP4zj8gDe\nCNzR9/oS4JJRj2sX453P9qGzFpjb2nOBtTuaB70VgG9s+zzaV38f8IlRz6uN5TZ699mb1nMCXgZ8\nnd7dM6btXOj9XtxdwNt4MXSm83we5xdDZ1rOBzgKeIz2mX7X8/Hy2r7Z0a125o1oLHtjTlU92dpP\nAXNae2fzmtfaU+sjlWQ+8Dp6ZwjTck7tUtQDwCZgVVVN27k0fw78V+BnfbXpPJ8C7kxyf3p3MoHp\nO5/jgc3A/2iXPz+V5OV0NB9DRwBU758q024pY5JXAJ8DPlBVW/u3Tac5VdULVXUKvTOERUlOnrJ9\n2swlyb8BNlXV/TvbZzrNp3lz+//z28BFSd7Sv3GazWcGvUvt11TV64Af0ruc9nPDnI+hs292e6ud\nA9zTSeYCtOdNrb6zeW1s7an1kUhyKL3A+XRVfb6Vp/WcquqfgK8CS5i+c3kT8K4kjwM3A29L8jdM\n3/lQVRvb8ybgC/TuYj9d57MB2NDOpgFupRdCnczH0Nk30/1WOyuBZa29jN7nIpP1pUkOS3I8sABY\n3U69tyY5ra1SObevT6fa+18HPFJVH+vbNO3mlGR2kle29uH0Ppt6lGk4F4CquqSqjq2q+fT+Ttxd\nVf+eaTqfJC9PcsRkGzgDeIhpOp+qegp4IslrWul0el/50s18RvGh3Dg9gHfQWzn1beCPRj2eXYzz\ns8CTwE/p/UvnPOBoeh/2rgPuBGb17f9HbU5r6VuRAiyk9xfu28BfMeXDyA7n82Z6p//fAh5oj3dM\nxzkBvw58o83lIeBPWn3azWUHc3srLy4kmJbzobc69ZvtsWby7/l0nU8bxynARPsz90VgZlfz8Y4E\nkqTOeHlNktQZQ0eS1BlDR5LUGUNHktQZQ0eS1BlDR5LUGUNHktQZQ0eS1Jn/DzA95lRQaJTFAAAA\nAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f1c74e36978>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rank_df['rank'].plot.hist(bins=20)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fea34ada128>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZgAAAD8CAYAAABKKbKtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3XuUpPVd5/H3p6v6Ot1zb24zgzMJQ3DQleAEs6vr0SCBxGwmniXLRI2oKO4uHI3xuIFkT4w5sidkNawXTMSAEk42A5Js0npwkUvU1U2AIcEEBlg6Q4AJk0zP/da3qvruH8+vZ2pqqruLmX66p6o+r0OfrvrV73n693QV8+nf5XkeRQRmZmZzrWOhG2BmZq3JAWNmZrlwwJiZWS4cMGZmlgsHjJmZ5cIBY2ZmuXDAmJlZLhwwZmaWCweMmZnlopjnziVdBfwhUAA+HREfq3m9G/gM8MPAHuCaiPh2eu1m4DqgDPx6RDwoqQf4R6A7tf3+iPidVH8dsAVYDnwNeG9ETMzUvpUrV8batWvn5mDNzNrEk08+uTsiBmerl1vASCoAtwNXADuAJyQNRcS2qmrXAfsi4gJJm4FbgWskbQA2AxcD5wEPS7oQGAfeEhGHJXUC/yTpbyPiq2nb2yJii6RPpX1/cqY2rl27lq1bt87pcZuZtTpJLzVSL88hssuA4YjYnnoSW4BNNXU2AXenx/cDl0tSKt8SEeMR8SIwDFwWmcOpfmf6irTNW9I+SPt8V14HZmZms8szYFYBr1Q935HK6taJiBJwAFgx07aSCpKeAnYBD0XEY2mb/Wkf0/0sMzObR3kGjOqU1V66ebo6024bEeWIuARYDVwm6Qca/FnZD5Sul7RV0taRkZFpG29mZqcnz4DZAayper4aeHW6OpKKwBJgbyPbRsR+4O+Bq4DdwNK0j+l+1tR2d0TExojYODg46xyVmZmdojwD5glgvaR1krrIJu2HauoMAdemx1cDj0Z2g5ohYLOk7rQ6bD3wuKRBSUsBJPUCPwU8l7b5ctoHaZ9fyvHYzMxsFrmtIouIkqQbgQfJlinfFRHPSPoosDUihoA7gXskDZP1XDanbZ+RdB+wDSgBN0REWdK5wN1phVoHcF9E/E36kR8Atkj6PeDrad9mZrZA1M53tNy4cWN4mbKZ2Wsj6cmI2DhbPZ/Jb/OiUgnufeJlxkvlhW6Kmc0TB4zNi7/b9l0+8Plv8sePDC90U8xsnjhgbF4cGstOUXp579EFbomZzRcHjM2LI+NZwJQqlQVuiZnNFweMzYu9R7LrjhY7/JEzaxf+v93mxehk+YTvZtb6HDA2L8ZL2dDY6IQDxqxdOGBsXoylnsuRidIsNc2sVThgbF6MTboHY9ZuHDA2L6ZOsDzqgDFrGw4YmxdTPRgHjFn7cMDYvJiag/GlYszahwPG5sVYWkU2UfKJlmbtwgFj82IqWCbKFdr5Ct5m7cQBY/NispwFTASUKg4Ys3bggLF5USofHxqbLHuYzKwdOGBsXkyWj/daPA9j1h4cMDYvqnstDhiz9uCAsXlRqgQ9ndnHbdwBY9YWHDA2LyZLFfq7i0C2kszMWp8DxubFZKVCb1cB8BCZWbtwwNi8mCwHi7pSD8YBY9YWHDCWu4igXAkWeYjMrK04YCx3U0uU+9IQ2aR7MGZtwQFjuZtaojw1yT/uHoxZW8g1YCRdJel5ScOSbqrzereke9Prj0laW/Xazan8eUlXprI1kr4s6VlJz0j6jar6H5H0HUlPpa+353ls1rjSsR6M52DM2kkxrx1LKgC3A1cAO4AnJA1FxLaqatcB+yLiAkmbgVuBayRtADYDFwPnAQ9LuhAoAb8VEV+TNAA8Kemhqn3eFhG/n9cx2amZONaD8Soys3aSZw/mMmA4IrZHxASwBdhUU2cTcHd6fD9wuSSl8i0RMR4RLwLDwGURsTMivgYQEYeAZ4FVOR6DzYFSJQuUXvdgzNpKngGzCnil6vkOTg6DY3UiogQcAFY0sm0aTnsj8FhV8Y2SviHpLknLTv8QbC5MDZEtmjoPxnMwZm0hz4BRnbLa67RPV2fGbSX1A58H3hcRB1PxJ4HXA5cAO4E/qNso6XpJWyVtHRkZmfkIbE5U0v1ffKKlWXvJM2B2AGuqnq8GXp2ujqQisATYO9O2kjrJwuWzEfGFqQoR8b2IKEdEBfhzsiG6k0TEHRGxMSI2Dg4OnsbhWaOm7v/S0+mAMWsneQbME8B6SeskdZFN2g/V1BkCrk2PrwYejex2h0PA5rTKbB2wHng8zc/cCTwbEZ+o3pGkc6ue/gzw9JwfkZ2ScuXE82A8RGbWHnJbRRYRJUk3Ag8CBeCuiHhG0keBrRExRBYW90gaJuu5bE7bPiPpPmAb2cqxGyKiLOnHgPcC35T0VPpRH4yIB4CPS7qEbCjt28Cv5XVs9tqU3YMxa0u5BQxA+of/gZqyD1c9HgPePc22twC31JT9E/XnZ4iI955uey0fUwFT7BCdBbkHY9YmfCa/5W5qDqZYEF2FDvdgzNqEA8ZyN9WDKXR00FnsOOHulmbWuhwwlrtjASP3YMzaiQPGcne8ByM6Cx2egzFrEw4Yy111wHQX3YMxaxcOGMvd1LXICh2iy3MwZm3DAWO5m7pUTHFqiMw9GLO24ICx3E1d7HKqB+M5GLP24ICx3E31YArpRMvJUu01T82sFTlgLHelqjP5u4oF3zLZrE04YCx3U6vIOjpEV0FMeg7GrC04YCx35RN6MJ6DMWsXDhjL3dQQWUc6k9/LlM3agwPGcleputillymbtQ8HjOWuVDlxmbJ7MGbtwQFjuau+2GVnoYNx92DM2oIDxnJ3fJK/w9ciM2sjDhjL3fFlytDpSX6ztuGAsdyVqnowXcUOKgElh4xZy3PAWO5OvFRM9pGbLPtyMWatzgFjuau92CXgeRizNuCAsdyVY+pES44HjIfIzFqeA8ZyV65UKHQIKbsWGThgzNqBA8ZyV6oEhY4sWDxEZtY+HDCWu0olKKaAOT7J74Axa3W5BoykqyQ9L2lY0k11Xu+WdG96/TFJa6teuzmVPy/pylS2RtKXJT0r6RlJv1FVf7mkhyS9kL4vy/PYrHGlSlBQ6sEU3IMxaxe5BYykAnA78DZgA/AeSRtqql0H7IuIC4DbgFvTthuAzcDFwFXAn6b9lYDfiojvB94M3FC1z5uARyJiPfBIem5ngEolKKS5l05P8pu1jTx7MJcBwxGxPSImgC3Appo6m4C70+P7gcslKZVviYjxiHgRGAYui4idEfE1gIg4BDwLrKqzr7uBd+V0XPYalaqGyLrdgzFrG3kGzCrglarnOzgeBifViYgScABY0ci2aTjtjcBjqejsiNiZ9rUTOGsOjsHmQLkSdOjESX7PwZi1vjwDRnXKak/fnq7OjNtK6gc+D7wvIg6+pkZJ10vaKmnryMjIa9nUTlG5ziS/ezBmrS/PgNkBrKl6vhp4dbo6korAEmDvTNtK6iQLl89GxBeq6nxP0rmpzrnArnqNiog7ImJjRGwcHBw8xUOz16JcCTo63IMxazd5BswTwHpJ6yR1kU3aD9XUGQKuTY+vBh6NiEjlm9Mqs3XAeuDxND9zJ/BsRHxihn1dC3xpzo/ITkk5Tu7B+J4wZq2vmNeOI6Ik6UbgQaAA3BURz0j6KLA1IobIwuIeScNkPZfNadtnJN0HbCNbOXZDRJQl/RjwXuCbkp5KP+qDEfEA8DHgPknXAS8D787r2Oy1qT7RstsnWpq1jdwCBiD9w/9ATdmHqx6PMU0QRMQtwC01Zf9E/fkZImIPcPlpNtlyUC4fDxhfTdmsffhMfstdOYJCR/ZRO36pmPJCNsnM5oEDxnJXrgSp40JnOuHSPRiz1ueAsdxlczA1PRivIjNreQ4Yy131xS59LTKz9uGAsdyVKpVjF7uURGdB7sGYtQEHjOWuUuHYKjLIejHuwZi1PgeM5a6U7mg5pbPY4TP5zdqAA8ZyV6460RLcgzFrFw4Yy131pWIgO9nSczBmrc8BY7krlY9f7BKyy8W4B2PW+hwwlrtKTQ+my3MwZm3BAWO5K9XMwXR6DsasLThgLHcnTfIXPQdj1g4cMJa72oDpLnYwPumAMWt1DhjLXbkSx87kB+jtLDA66aspm7W6hgJG0ucl/bQkB5K9ZuVKUCwcD5iergJjDhizltdoYHwS+FngBUkfk3RRjm2yFlM7RNZTLDDmITKzltdQwETEwxHxc8ClwLeBhyT9X0m/JKkzzwZa8yvVDpF1dXiIzKwNNDzkJWkF8IvArwBfB/6QLHAeyqVl1jIqVfeDgTQHM+GAMWt1xUYqSfoCcBFwD/DvImJneuleSVvzapy1hlLVHS3h+CR/RKCqno2ZtZaGAgb4dEQ8UF0gqTsixiNiYw7tshZSrunBdHcWABgvVehJj82s9TQ6RPZ7dcq+MpcNsdZVe7HL3hQqXklm1tpm7MFIOgdYBfRKeiMw9a/EYqAv57ZZC4gIypUTL3bZ25UFzOhkmaUL1TAzy91sQ2RXkk3srwY+UVV+CPhgTm2yFlKJ7Hu9Hown+s1a24wBExF3A3dL+vcR8fl5apO1kFIlO9/lhPNgOrORWZ8LY9baZpyDkfTz6eFaSe+v/Zpt55KukvS8pGFJN9V5vVvSven1xyStrXrt5lT+vKQrq8rvkrRL0tM1+/qIpO9Ieip9vX229ln+yqkLc2LAHB8iM7PWNdsk/6L0vR8YqPM1LUkF4HbgbcAG4D2SNtRUuw7YFxEXALcBt6ZtNwCbgYuBq4A/TfsD+MtUVs9tEXFJ+npgmjo2j6YCxpP8Zu1ntiGyP0vff/cU9n0ZMBwR2wEkbQE2Aduq6mwCPpIe3w/8ibITIzYBWyJiHHhR0nDa31ci4h+rezp2ZpsKmA7VmeT3HIxZS2v0Ypcfl7RYUqekRyTtrho+m84q4JWq5ztSWd06EVECDgArGty2nhslfSMNoy1roL7l7FgPpuAhMrN20+h5MG+NiIPAO8j+sb8Q+O1Ztql3inY0WKeRbWt9Eng9cAmwE/iDuo2Srpe0VdLWkZGRWXZpp6veHMyi7qzjfHSitCBtMrP50WjATF3Q8u3A5yJibwPb7ADWVD1fDbw6XR1JRWAJsLfBbU8QEd+LiHJEVIA/JxtSq1fvjojYGBEbBwcHGzgMOx2lqYCpGiLr78oC5vC4ezBmrazRgPlrSc8BG4FHJA0CY7Ns8wSwXtI6SV1kk/ZDNXWGgGvT46uBRyMiUvnmtMpsHbAeeHymHybp3KqnPwM8PV1dmz/1ezDZENnhMfdgzFpZQ9cii4ibJN0KHIyIsqQjZBPxM21TknQj8CBQAO6KiGckfRTYGhFDwJ3APWkSfy9ZCJHq3Ue2IKAE3BARZQBJnwN+AlgpaQfwOxFxJ/BxSZeQDaV9G/i11/KLsHzUC5hioYPezgKHxycXqllmNg8avdglwPeTnQ9Tvc1nZtogLRV+oKbsw1WPx4B3T7PtLcAtdcrfM039987UFlsY5Tg5YAD6e4ocHncPxqyVNXq5/nvIJtCfAqYGzoNZAsbs+HkwJ47GDnQXOeQhMrOW1mgPZiOwIc2PmDWsVJ7qwZxYvqi7yBH3YMxaWqOT/E8D5+TZEGtNlWNDZCd+1Pq7PURm1uoa7cGsBLZJehwYnyqMiHfm0iprGceWKdf8KdPfU+SVvUcXoEVmNl8aDZiP5NkIa13HV5GdPAfjHoxZa2t0mfI/SPo+YH1EPCypj2zpsdmM6l3sErIejOdgzFpbo9ci+1Wyi1H+WSpaBXwxr0ZZ65i6H0z1xS4BBnqKHBwr4XUjZq2r0Un+G4AfBQ4CRMQLwFl5NcpaR8qXEy52CbCsr4tyJTjkXoxZy2o0YMYjYmLqSTrZ0n962qym68Es6c0ub7f/iM/mN2tVjQbMP0j6INAr6Qrgr4C/zq9Z1iqmm4NZ1tcFwL6jEydtY2atodGAuQkYAb5Jdo2vB4D/mlejrHXUuxYZwLJFWQ/GAWPWuhpdRVaR9EXgixHhm6hYw6YLmKWpB7P/qIfIzFrVjD0YZT4iaTfwHPC8pBFJH55pO7Mp013sctmxgHEPxqxVzTZE9j6y1WNviogVEbEc+BHgRyX9Zu6ts6Y3dS2y2jmYxT1Z53mfezBmLWu2gPkF4D0R8eJUQURsB34+vWY2o9I0V1MuFjpY3FN0D8ashc0WMJ0Rsbu2MM3DdNapb3aCclqmXHseDMCyRV3uwZi1sNkCZqY/L/2np82qNM0yZcgm+r2KzKx1zbaK7IckHaxTLqAnh/ZYi5luFRnAsr5O9hx2wJi1qhkDJiJ8QUs7Lccn+U/uLC/r62J41+H5bpKZzZNGT7Q0OyXHejB15mCWL+pyD8ashTlgLFczzcGs7O9mdLLM0Qlf8NKsFTlgLFdTq8jqzcGs7M9Ottx9yL0Ys1bkgLFcHbtlsur3YABGDo+f9JqZNT8HjOWqXAk6BB3TDJEB7HHAmLUkB4zlqlSJuivIAFYOpCEyT/SbtaRcA0bSVZKelzQs6aY6r3dLuje9/piktVWv3ZzKn5d0ZVX5XZJ2SXq6Zl/LJT0k6YX0fVmex2aNKZUrdedfIFtFBrDbPRizlpRbwEgqALcDbwM2AO+RtKGm2nXAvoi4ALgNuDVtuwHYDFwMXAX8adofwF+mslo3AY9ExHrgkfTcFljWg6kfMN3FAot7iicMkUWEr09m1iLy7MFcBgxHxPZ0u+UtwKaaOpuAu9Pj+4HLJSmVb4mI8XShzeG0PyLiH4G9dX5e9b7uBt41lwdjp6ZcibrnwExZOdB9whDZxx98nh/+vYf5yrf2zEfzzCxHeQbMKuCVquc7UlndOhFRAg4AKxrcttbZEbEz7WsncNYpt9zmzExzMAArF3UfGyIrV4LPfvUlypXgc4+/PF9NNLOc5Bkw9f5sjQbrNLLtKZF0vaStkraOjPjmnHkrl6cfIoNson8qYF7ee5SDY9lJl/+yY/+8tM/M8pNnwOwA1lQ9Xw28Ol0dSUVgCdnwVyPb1vqepHPTvs4FdtWrFBF3RMTGiNg4ODjY4KHYqSpVYtpJfoAVi44PkU1dl+yKDWfz0p6jHBj1pfzNmlmeAfMEsF7SOkldZJP2QzV1hoBr0+OrgUcjIlL55rTKbB2wHnh8lp9Xva9rgS/NwTHYaSpXKnXvBTNlZX83B0YnmShVeGHXIQDedUk2Grrt1XoX8jazZpFbwKQ5lRuBB4Fngfsi4hlJH5X0zlTtTmCFpGHg/aSVXxHxDHAfsA3438ANEVEGkPQ54CvAGyTtkHRd2tfHgCskvQBckZ7bAputBzM4kJ1sufvwOMPfO8w5i3v4V6uXAPDtPUfmpY1mlo/Z7gdzWiLiAeCBmrIPVz0eA949zba3ALfUKX/PNPX3AJefTntt7pVnWKYMsGpZLwDf2T/KC7sOs/7sfs5b2ktnQby89+h8NdPMcuAz+S1XWQ9m+o/ZqqVZwLyy9yjfGjnM6wf7KXSI1cv6eHmPA8asmTlgLFez9WBWpx7M4y/u5ehEmQvPHgDg/OV9vLTXQ2RmzcwBY7mabQ6mp7PAyv4uHn0uW/T3hnP6gRQwe46Srfkws2bkgLFclSuVGXswkIXJrkPZuTAXnJX1YL5vRR+HxkpeqmzWxBwwlqvJ8sw9GIAfXJWtGhsc6GZJbyeQhQ7AS56HMWtaDhjLVbkSM54HA/COHzoPgP+wcfWxsvNXpIDxSjKzppXrMmWz2a5FBvCmtct5/EOXM5huQAbHezAv+1wYs6blgLFcNTIHA3DWQM8Jz/u6iqxY1MV39o/m1TQzy5mHyCxXpQbmYKazelkvO/Y5YMyalQPGctXIHMx0Vi3r5TsOGLOm5YCxXJVnOZN/JquX9fGd/aM+F8asSTlgLFcz3TJ5NquW9jJeqjBSdUtlM2seDhjLVXmWM/lnMnUZGQ+TmTUnB4zlqtTgKrJ6pq607Il+s+bkgLFcnU4P5twlWcB898DYXDbJzOaJA8ZydTpzMIt7inQVOtjtORizpuSAsVxl58Gc2sdMEoMD3Z7kN2tSDhjL1US5Qlfx1D9mK/u72H14Yg5bZGbzxQFjuYkIJkoVuk7xREuAlf3djBxyD8asGTlgLDelSnaCZGfh1D9mgwPdnoMxa1IOGMvNZLkCcJpDZN3sOTxOpeKz+c2ajQPGcjNZOv0ezNK+TioBh8ZKc9UsM5snDhjLzUTqwXSeRg9m6g6XvnWyWfNxwFhupgLmdCb5HTBmzcsBY7mZLKUezGkMkTlgzJpXrgEj6SpJz0salnRTnde7Jd2bXn9M0tqq125O5c9LunK2fUr6S0kvSnoqfV2S57HZ7OZikn9JnwPGrFnldstkSQXgduAKYAfwhKShiNhWVe06YF9EXCBpM3ArcI2kDcBm4GLgPOBhSRembWba529HxP15HZO9NsfmYNyDMWtLefZgLgOGI2J7REwAW4BNNXU2AXenx/cDl0tSKt8SEeMR8SIwnPbXyD7tDDFZzlaRdTlgzNpSngGzCnil6vmOVFa3TkSUgAPAihm2nW2ft0j6hqTbJHXPxUHYqZuYgzmY3s4CnQU5YMyaUJ4BU2/pUO3ZctPVea3lADcDFwFvApYDH6jbKOl6SVslbR0ZGalXxebI5LEhslNfRSaJJb2dDhizJpRnwOwA1lQ9Xw28Ol0dSUVgCbB3hm2n3WdE7IzMOPAXZMNpJ4mIOyJiY0RsHBwcPMVDs0ZMzMEkP8Di3k4OOmDMmk6eAfMEsF7SOkldZJP2QzV1hoBr0+OrgUcjIlL55rTKbB2wHnh8pn1KOjd9F/Au4Okcj80aMBfLlAH3YMyaVG6ryCKiJOlG4EGgANwVEc9I+iiwNSKGgDuBeyQNk/VcNqdtn5F0H7ANKAE3REQZoN4+04/8rKRBsmG0p4D/mNexWWOOTfKfZg9mSW8ne3zJfrOmk1vAAETEA8ADNWUfrno8Brx7mm1vAW5pZJ+p/C2n216bWxPlMjA3PZjtI0fmoklmNo98Jr/l5vjFLk99kh88RGbWrBwwlpu5muRf0tvJobFJX7LfrMk4YCw3xy4VMwdDZJWAwxO+ZL9ZM3HAWG7m4kRLgMU96Wz+ox4mM2smDhjLzeQcXIsMsvNgAA6OOWDMmokDxnIzUZ6bSf7FvdliR0/0mzUXB4zlZrJcoavQQXbu66mbuuDlwVHPwZg1EweM5WaiVDnt3gtUB4x7MGbNxAFjuRmdLNPbVTjt/Sz2JfvNmpIDxnIzNlGmp/P0A6a/q0iHPMlv1mwcMJab0ckyvXMQMB0dYqDHZ/ObNRsHjOVmbI6GyCCbh/EcjFlzccBYbkYn52aIDHw9MrNm5ICx3IxOVuZkiAyyc2EcMGbNxQFjuRmbmJs5GHAPxqwZOWAsN0cmSnM2B7NiUTd7jvimY2bNxAFjuTk8XmKgZ27uaTc40M3+o5PHLqBpZmc+B4zlIiI4NFaiv3tuAmZlfzcAe46Mz8n+zCx/DhjLxdhkhXIlGEiX2j9dgwNZwIwccsCYNQsHjOXiUDrrfi6HyMABY9ZMHDCWi4Nj2ZWP5ypgVvZ3AbD7sAPGrFk4YCwXe9OKr+WLuuZkf4MD3XQIvrNvdE72Z2b5c8BYLvaknsbU5Pzp6i4WWLO8j2+NHJmT/ZlZ/hwwloupoawV/XPTgwG4YLCfb40cnrP9mVm+HDCWi1cPjFHsEMv75i5gXn9WP9t3H6FU9rkwZs1gbmZgpyHpKuAPgQLw6Yj4WM3r3cBngB8G9gDXRMS302s3A9cBZeDXI+LBmfYpaR2wBVgOfA14b0T41O8F8tKeI6xZ3kexMHd/w/zQ6qVMlCpsfWkfb37dijnb73x5df8o/+eFEbbvPsLR8TIHRifZd3SCA6OTHB4vMVGqsKiryEBPkaV9naxZ3sfrBvt5w9kDXHTuAIvnaMm32XzJLWAkFYDbgSuAHcATkoYiYltVteuAfRFxgaTNwK3ANZI2AJuBi4HzgIclXZi2mW6ftwK3RcQWSZ9K+/5kXsdnM3tu5yFeP9g/p/v8yYsG6ens4DNf+TaXnr+MQoeYKFWyr3KFIFjW10XnHIZarYgAQJr5VtAHxybZsXeU7bsP88SLe/nnb+1heFc2vNdV6KCvu8CS3k6W9nWxfFEXa5b30VXo4Mh4iUNjJXbsG+Wfh/cwOlk+ts9VS3tZvayX/u4ifd1FFvcUWbEo2355fzfnLelh/VkDLOnLgmiiVOHA6CQHRifYf3SS/UePB9qB0Uk6JL7/3MVcev5Szlrck9NvzNpZnj2Yy4DhiNgOIGkLsAmoDphNwEfS4/uBP1H2f+4mYEtEjAMvShpO+6PePiU9C7wF+NlU5+60XwfMAhjedZjtu4/wnsvOn9P99nUV+dV/+zr++NFhHvjm305bb2lfJysWdbFiUTcr+rsodIjJcoVSOZhI3yspKKpFZNdPOzpRZnyyjCQ6UlaNTlQYnSgxOlmmkjaVoENCZN/J/gNgvOqSNr2dBTauXcY1G9fw4xcOcuHZ/bMGVNaeYOeBMZ7/7iG27TzIszsPsuvgON89OMaR8RIHRifZPzpJ7aH0dhYIgrHJ6YcSU3OPHcuqpb1cdM4Aa5b3sXpZL8v6uhjoKbK4t5OBniKLuor0dRdY1FWkt7NAR8fs7TfLM2BWAa9UPd8B/Mh0dSKiJOkAsCKVf7Vm21Xpcb19rgD2R0SpTv0590ePvMDQv7x67HnU/B9+0j9dMePTWbev/Qckamqc9PrJ/3bm+/Nqtj8wOkl/d5FNbzxv5oacgvdfcSE/sGoJz+08BEBXsePYFxHsPTLJniPj7Dk8we7D47yw6zCVStBZ6KBYEJ2FDjoLygKhRkcHnLO4h77uIt3FDiKy31UAPZ0d9HYW6esqUOgQQXotoJLqVNdfsaiL1cv6OH95HxedO3BKvSpJnLe0l/OW9vKTF51Vt065Euw/OsHeIxO8su8ow7sOHzsZdaCnk2V9nSzp62JpbydL+zpZ2tvFkr5OBrqLTJQrbNt5kK+9tI+vv7Kf7SNHeOzFvRweL9X9WcfblYVYoSMLV0knhG32q9WxEMu+iw4d7/lJx8urt60O6WbSyB8MZ5r/9jM/yGXrluf6M/IMmHpvKTaBAAAG4ElEQVS/8dp/i6arM115vf9LZ6p/cqOk64HrAc4//9T+wj5roJs3nD1Qs+MZn570ATz59dPb/uSfX1N/1v2/xu1naEBPZwfXvGkNZw3M/bCLJK68+ByuvPicOd93Myp0iBX93azo72b92QO85aKzG962p6PApecv49Lzlx0riwgOjma9o4NjkxwcneTgWInRyRKHx8scHS9xZCL7Xkrdn6gK2OqwhUihm/2RUql6nP6ru23TacpGw6LuubnS+UzyDJgdwJqq56uBV6eps0NSEVgC7J1l23rlu4GlkoqpF1PvZwEQEXcAdwBs3LjxlD4amy87n81zPPxjdiaQxJK+zmPzOGanI89lyk8A6yWtk9RFNmk/VFNnCLg2Pb4aeDSy8ZshYLOk7rQ6bD3w+HT7TNt8Oe2DtM8v5XhsZmY2i9x6MGlO5UbgQbIlxXdFxDOSPgpsjYgh4E7gnjSJv5csMEj17iNbEFACboiIMkC9faYf+QFgi6TfA76e9m1mZgtEtRO+7WTjxo2xdevWhW6GmVlTkfRkRGycrZ7P5Dczs1w4YMzMLBcOGDMzy4UDxszMcuGAMTOzXLT1KjJJI8BLC92OaawkO4G0Vfh4zmw+njPbmXY83xcRg7NVauuAOZNJ2trIMsBm4eM5s/l4zmzNejweIjMzs1w4YMzMLBcOmDPXHQvdgDnm4zmz+XjObE15PJ6DMTOzXLgHY2ZmuXDALBBJ/13Sc5K+Iel/SVpa9drNkoYlPS/pyqryq1LZsKSbqsrXSXpM0guS7k23MjhjTNfuM4mkNZK+LOlZSc9I+o1UvlzSQ+l3+5CkZalckv4oHdM3JF1ata9rU/0XJF073c+cD5IKkr4u6W/S87qflXRrjHvT8TwmaW3VPup+HuebpKWS7k//3zwr6V838/sj6TfTZ+1pSZ+T1NPM709d2W1f/TXfX8BbgWJ6fCtwa3q8AfgXoBtYB3yL7NYEhfT4dUBXqrMhbXMfsDk9/hTwnxb6+KqOc9p2n0lfwLnApenxAPD/0nvxceCmVH5T1fv0duBvyW7l+WbgsVS+HNievi9Lj5ct4HG9H/ifwN/M9FkB/jPwqfR4M3DvTJ/HBTqWu4FfSY+7gKXN+v6Q3dL9RaC36n35xWZ+f+p9uQezQCLi7yK7+ybAV8nuwgmwCdgSEeMR8SIwDFyWvoYjYntETABbgE2SBLwFuD9tfzfwrvk6jgbUbfcCt+kkEbEzIr6WHh8CniX7R2AT2e8UTvzdbgI+E5mvkt1R9VzgSuChiNgbEfuAh4Cr5vFQjpG0Gvhp4NPp+UyflerjvB+4PNWf7vM4ryQtBn6cdJ+niJiIiP008ftDdj+uXmV38+0DdtKk7890HDBnhl8m+2sLsn/UXql6bUcqm658BbC/Kqymys8U07X7jJWGH94IPAacHRE7IQsh4KxU7bW+TwvhfwD/Baik5zN9Vo61O71+INU/U47ndcAI8BdpyO/TkhbRpO9PRHwH+H3gZbJgOQA8SfO+P3U5YHIk6eE0vlr7tamqzofI7tr52amiOruKUyg/U5zp7TuBpH7g88D7IuLgTFXrlJ0x74ekdwC7IuLJ6uI6VWOW186I4yH7a/9S4JMR8UbgCNmQ2HTO6ONJc0WbyIa1zgMWAW+rU7VZ3p+6crtlskFE/NRMr6cJxncAl0caUCX7C2RNVbXVwKvpcb3y3WTd/2L6y6a6/plgpuM5o0jqJAuXz0bEF1Lx9ySdGxE70xDLrlQ+3XHtAH6ipvzv82z3NH4UeKektwM9wGKyHs10n5Wp49mRhmyWkN3G/Ex5/3YAOyLisfT8frKAadb356eAFyNiBEDSF4B/Q/O+P3W5B7NAJF0FfAB4Z0QcrXppCNicVo2sA9YDjwNPAOvTKpMusom+oRRMXwauTttfC3xpvo6jAXXbvcBtOkkaz74TeDYiPlH10hDZ7xRO/N0OAb+QViu9GTiQhmgeBN4qaVn6K/WtqWxeRcTNEbE6ItaS/c4fjYifY/rPSvVxXp3qB9N/HudVRHwXeEXSG1LR5cA2mvT9IRsae7OkvvTZmzqepnx/prXQqwza9YtsMu4V4Kn09amq1z5EthrkeeBtVeVvJ1vd9C3gQ1XlryP7UA0DfwV0L/Tx1Rxr3XafSV/Aj5ENLXyj6j15O9k49yPAC+n78lRfwO3pmL4JbKza1y+n92IY+KUz4Nh+guOryOp+Vsh6OX+Vyh8HXjfb53EBjuMSYGt6j75Itgqsad8f4HeB54CngXvIVoI17ftT78tn8puZWS48RGZmZrlwwJiZWS4cMGZmlgsHjJmZ5cIBY2ZmuXDAmJlZLhwwZmaWCweMmZnl4v8DF0lzQYkVgtgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "rank_df['rank'].plot.density()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Progress: [####################] 100.0%\n"
+     ]
+    }
+   ],
+   "source": [
+    "test_rank_dict = {\n",
+    "    'date': [],\n",
+    "    'from': [],\n",
+    "    'subject': [],\n",
+    "    'rank': []\n",
+    "}\n",
+    "\n",
+    "for i in range(priority_test.shape[0]):\n",
+    "    result = rank_message(priority_test.iloc[i, :])\n",
+    "    test_rank_dict['date'].append(result[0])\n",
+    "    test_rank_dict['from'].append(result[1])\n",
+    "    test_rank_dict['subject'].append(result[2])\n",
+    "    test_rank_dict['rank'].append(result[3])\n",
+    "    update_progress(i/priority_test.shape[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_rank_df = pd.DataFrame.from_dict(test_rank_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "6.650229808226872\n"
+     ]
+    }
+   ],
+   "source": [
+    "priority_threshold = test_rank_df['rank'].median()\n",
+    "print(priority_threshold)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_rank_df['priority'] = test_rank_df['rank']>priority_threshold"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>date</th>\n",
+       "      <th>from</th>\n",
+       "      <th>rank</th>\n",
+       "      <th>subject</th>\n",
+       "      <th>priority</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2001-11-27 01:39:16</td>\n",
+       "      <td>(christian.yoder@enron.com)</td>\n",
+       "      <td>22.676505</td>\n",
+       "      <td>hyda index -2</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>2001-11-27 01:56:04</td>\n",
+       "      <td>(s..bradford@enron.com)</td>\n",
+       "      <td>15.506970</td>\n",
+       "      <td>fw: physical gas collections 11/26/01</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>2001-11-27 01:56:07</td>\n",
+       "      <td>(ken.e.randolph@dynegy.com)</td>\n",
+       "      <td>17.738310</td>\n",
+       "      <td>re: lunch</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>2001-11-27 01:56:38</td>\n",
+       "      <td>(mariella.mahan@enron.com)</td>\n",
+       "      <td>7.117388</td>\n",
+       "      <td>fw: guam information</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>15</th>\n",
+       "      <td>2001-11-27 01:58:02</td>\n",
+       "      <td>(cara.semperger@enron.com)</td>\n",
+       "      <td>28.390146</td>\n",
+       "      <td>re: dart product</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                  date                         from       rank  \\\n",
+       "3  2001-11-27 01:39:16  (christian.yoder@enron.com)  22.676505   \n",
+       "9  2001-11-27 01:56:04      (s..bradford@enron.com)  15.506970   \n",
+       "10 2001-11-27 01:56:07  (ken.e.randolph@dynegy.com)  17.738310   \n",
+       "11 2001-11-27 01:56:38   (mariella.mahan@enron.com)   7.117388   \n",
+       "15 2001-11-27 01:58:02   (cara.semperger@enron.com)  28.390146   \n",
+       "\n",
+       "                                  subject  priority  \n",
+       "3                           hyda index -2      True  \n",
+       "9   fw: physical gas collections 11/26/01      True  \n",
+       "10                              re: lunch      True  \n",
+       "11                   fw: guam information      True  \n",
+       "15                       re: dart product      True  "
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_rank_df[test_rank_df.priority].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fea2418cd68>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZUAAAD8CAYAAAC/1zkdAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAFSxJREFUeJzt3X/wXXV95/Hny+AP8EcDElg2xAbajIU6EjDFOHR3FVsMuBXc0R3ZTsk4bNPphhmddWYN7m5xtczgzAotU8uKJSu4KuJPUo2lkWJtZyoQfpSfskmRlZgsCQ0C1S4UfO8f9/OVa7jf7/cmnJubI8/HzJl7zvueH+8TLnnl/LjnpqqQJKkLL5h2A5Kknx2GiiSpM4aKJKkzhookqTOGiiSpM4aKJKkzhookqTOGiiSpM4aKJKkzB027gf3t8MMPr6VLl067DUnqlVtuueXhqlo033zPu1BZunQpmzdvnnYbktQrSf7POPN5+kuS1BlDRZLUGUNFktSZiYVKkiVJbkhyb5K7k7yn1T+Y5PtJbm/DGUPLnJ9ka5L7krxlqL6q1bYmWTdUPybJjUm2JPlckhdNan8kSfOb5JHKU8D7quo4YCWwNsnx7b1Lqmp5GzYCtPfeBfwysAr44yQLkiwAPgacDhwPnD20no+0dS0DHgHOneD+SJLmMbFQqaodVXVrG38cuBdYPMciZwJXV9UTVfVdYCtwchu2VtX9VfUkcDVwZpIApwJfaMtfCZw1mb2RJI1jv1xTSbIUOBG4sZXOS3JHkvVJDm21xcCDQ4tta7XZ6q8EflBVT+1RlyRNycRDJcnLgC8C762qx4DLgF8AlgM7gI/OzDpi8dqH+qge1iTZnGTzrl279nIPJEnjmmioJHkhg0D5dFV9CaCqHqqqp6vqx8AnGJzegsGRxpKhxY8Gts9RfxhYmOSgPerPUlWXV9WKqlqxaNG8XwiVJO2jiX2jvl3zuAK4t6ouHqofVVU72uTbgbva+AbgM0kuBv45sAy4icERybIkxwDfZ3Ax/99VVSW5AXgHg+ssq4FrJ7U/AEvXfW1k/YGL3jrJzUpSb0zyMS2nAL8F3Jnk9lb7AIO7t5YzOFX1APA7AFV1d5JrgHsY3Dm2tqqeBkhyHnAdsABYX1V3t/W9H7g6ye8DtzEIMUnSlEwsVKrqrxl93WPjHMtcCFw4or5x1HJVdT/PnD6TJE2Z36iXJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1xlCRJHXGUJEkdcZQkSR1ZmKhkmRJkhuS3Jvk7iTvafXDkmxKsqW9HtrqSXJpkq1J7khy0tC6Vrf5tyRZPVR/XZI72zKXJsmk9keSNL9JHqk8Bbyvqo4DVgJrkxwPrAOur6plwPVtGuB0YFkb1gCXwSCEgAuA1wMnAxfMBFGbZ83QcqsmuD+SpHlMLFSqakdV3drGHwfuBRYDZwJXttmuBM5q42cCV9XAt4GFSY4C3gJsqqrdVfUIsAlY1d57RVX9TVUVcNXQuiRJU7BfrqkkWQqcCNwIHFlVO2AQPMARbbbFwINDi21rtbnq20bUR21/TZLNSTbv2rXrue6OJGkWEw+VJC8Dvgi8t6oem2vWEbXah/qzi1WXV9WKqlqxaNGi+VqWJO2jiYZKkhcyCJRPV9WXWvmhduqK9rqz1bcBS4YWPxrYPk/96BF1SdKUTPLurwBXAPdW1cVDb20AZu7gWg1cO1Q/p90FthJ4tJ0euw44Lcmh7QL9acB17b3Hk6xs2zpnaF2SpCk4aILrPgX4LeDOJLe32geAi4BrkpwLfA94Z3tvI3AGsBX4EfBugKraneTDwM1tvg9V1e42/rvAJ4GDga+3QZI0JRMLlar6a0Zf9wB484j5C1g7y7rWA+tH1DcDr3kObUqSOuQ36iVJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdMVQkSZ0xVCRJnTFUJEmdGStUkrxm0o1Ikvpv3COV/5HkpiT/IcnCiXYkSeqtsUKlqn4V+E1gCbA5yWeS/PpEO5Mk9c7Y11SqagvwX4D3A/8KuDTJd5L8m0k1J0nql3Gvqbw2ySXAvcCpwG9U1XFt/JJZllmfZGeSu4ZqH0zy/SS3t+GMoffOT7I1yX1J3jJUX9VqW5OsG6ofk+TGJFuSfC7Ji/Z67yVJnRr3SOWPgFuBE6pqbVXdClBV2xkcvYzySWDViPolVbW8DRsBkhwPvAv45bbMHydZkGQB8DHgdOB44Ow2L8BH2rqWAY8A5465L5KkCRk3VM4APlNV/wiQ5AVJDgGoqk+NWqCqvgXsHnP9ZwJXV9UTVfVdYCtwchu2VtX9VfUkcDVwZpIwOEr6Qlv+SuCsMbclSZqQcUPlG8DBQ9OHtNq+OC/JHe302KGtthh4cGieba02W/2VwA+q6qk96iMlWZNkc5LNu3bt2se2JUnzGTdUXlJV/zAz0cYP2YftXQb8ArAc2AF8tNUzYt7ah/pIVXV5Va2oqhWLFi3au44lSWMbN1R+mOSkmYkkrwP+cW83VlUPVdXTVfVj4BMMTm/B4EhjydCsRwPb56g/DCxMctAedUnSFI0bKu8FPp/kr5L8FfA54Ly93ViSo4Ym3w7M3Bm2AXhXkhcnOQZYBtwE3Awsa3d6vYjBxfwNVVXADcA72vKrgWv3th9JUrcOmn8WqKqbk/wS8GoGp56+U1X/NNcyST4LvBE4PMk24ALgjUmWMzhV9QDwO239dye5BrgHeApYW1VPt/WcB1wHLADWV9XdbRPvB65O8vvAbcAV4+60JGkyxgqV5leApW2ZE5NQVVfNNnNVnT2iPOtf/FV1IXDhiPpGYOOI+v08c/pMknQAGCtUknyKwQX224GnW7mAWUNFkvT8M+6Rygrg+HYtQ5Kkkca9UH8X8M8m2Ygkqf/GPVI5HLgnyU3AEzPFqnrbRLqSJPXSuKHywUk2IUn62TDuLcV/meTngWVV9Y323K8Fk21NktQ34z76/rcZPLzx4620GPjKpJqSJPXTuBfq1wKnAI/BT36w64hJNSVJ6qdxQ+WJ9uh5ANozt7y9WJL0U8YNlb9M8gHg4Pbb9J8H/nRybUmS+mjcUFkH7ALuZPC8ro3M/ouPkqTnqXHv/pp5VP0nJtuOJKnPxn3213cZcQ2lqo7tvCNJUm/tzbO/ZrwEeCdwWPftSJL6bKxrKlX190PD96vqD4BTJ9ybJKlnxj39ddLQ5AsYHLm8fCIdSZJ6a9zTXx8dGn+Kwa82/tvOu5Ek9dq4d3+9adKNSJL6b9zTX/9xrver6uJu2pEk9dne3P31K8CGNv0bwLeAByfRlCSpn/bmR7pOqqrHAZJ8EPh8Vf37STUmSeqfcR/T8irgyaHpJ4GlnXcjSeq1cY9UPgXclOTLDL5Z/3bgqol1JUnqpXHv/rowydeBf9FK766q2ybXliSpj8Y9/QVwCPBYVf0hsC3JMRPqSZLUU+P+nPAFwPuB81vphcD/mlRTkqR+GvdI5e3A24AfAlTVdnxMiyRpD+OGypNVVbTH3yd56eRakiT11bihck2SjwMLk/w28A38wS5J0h7Gvfvrv7ffpn8MeDXwe1W1aaKdSZJ6Z95QSbIAuK6qfg0wSCRJs5r39FdVPQ38KMnP7Yd+JEk9Nu41lf8H3JnkiiSXzgxzLZBkfZKdSe4aqh2WZFOSLe310FZPW+fWJHcM/yhYktVt/i1JVg/VX5fkzrbMpUmyd7suSerauKHyNeC/Mngy8S1Dw1w+Cazao7YOuL6qlgHXt2mA04FlbVgDXAaDEAIuAF4PnAxcMBNEbZ41Q8vtuS1J0n425zWVJK+qqu9V1ZV7u+Kq+laSpXuUzwTe2MavBL7J4EuVZwJXtduWv51kYZKj2rybqmp362cTsCrJN4FXVNXftPpVwFnA1/e2T0lSd+Y7UvnKzEiSL3awvSOragdAez2i1Rfz07/Nsq3V5qpvG1GXJE3RfKEyfJ3i2An2Mep6SO1DffTKkzVJNifZvGvXrn1sUZI0n/lCpWYZ31cPtdNatNedrb4NWDI039HA9nnqR4+oj1RVl1fViqpasWjRoue8E5Kk0eYLlROSPJbkceC1bfyxJI8neWwftrcBmLmDazVw7VD9nHYX2Erg0XZ67DrgtCSHtgv0pzH4zswO4PEkK9tdX+cMrUuSNCVzXqivqgX7uuIkn2Vwof3wJNsY3MV1EYNHvpwLfA94Z5t9I3AGsBX4EfDutv3dST4M3Nzm+9DMRXvgdxncYXYwgwv0XqSXpCkb95cf91pVnT3LW28eMW8Ba2dZz3pg/Yj6ZuA1z6VHSVK39uZHuiRJmpOhIknqjKEiSeqMoSJJ6oyhIknqjKEiSeqMoSJJ6oyhIknqjKEiSeqMoSJJ6oyhIknqjKEiSeqMoSJJ6oyhIknqjKEiSeqMoSJJ6szEfqTr+WTpuq+NrD9w0Vv3cyeSNF0eqUiSOmOoSJI6Y6hIkjpjqEiSOmOoSJI6Y6hIkjpjqEiSOmOoSJI6Y6hIkjpjqEiSOmOoSJI6Y6hIkjpjqEiSOmOoSJI6Y6hIkjpjqEiSOjOVUEnyQJI7k9yeZHOrHZZkU5It7fXQVk+SS5NsTXJHkpOG1rO6zb8lyepp7Isk6RnTPFJ5U1Utr6oVbXodcH1VLQOub9MApwPL2rAGuAwGIQRcALweOBm4YCaIJEnTcSCd/joTuLKNXwmcNVS/qga+DSxMchTwFmBTVe2uqkeATcCq/d20JOkZ0wqVAv48yS1J1rTakVW1A6C9HtHqi4EHh5bd1mqz1SVJU3LQlLZ7SlVtT3IEsCnJd+aYNyNqNUf92SsYBNcagFe96lV726skaUxTOVKpqu3tdSfwZQbXRB5qp7Vorzvb7NuAJUOLHw1sn6M+anuXV9WKqlqxaNGiLndFkjRkv4dKkpcmefnMOHAacBewAZi5g2s1cG0b3wCc0+4CWwk82k6PXQecluTQdoH+tFaTJE3JNE5/HQl8OcnM9j9TVX+W5GbgmiTnAt8D3tnm3wicAWwFfgS8G6Cqdif5MHBzm+9DVbV7/+2GJGlP+z1Uqup+4IQR9b8H3jyiXsDaWda1HljfdY+SpH1zIN1SLEnqOUNFktQZQ0WS1BlDRZLUGUNFktQZQ0WS1BlDRZLUmWk9++t5Yem6r42sP3DRW/dzJ5K0f3ikIknqjKEiSeqMoSJJ6oyhIknqjKEiSeqMoSJJ6oyhIknqjKEiSeqMoSJJ6ozfqJ8Cv2kv6WeVRyqSpM4YKpKkzhgqkqTOGCqSpM4YKpKkzhgqkqTOGCqSpM74PZUe8HstkvrCIxVJUmcMFUlSZwwVSVJnDBVJUmcMFUlSZwwVSVJnDBVJUmd6/z2VJKuAPwQWAH9SVRdNuaV9Ntv3USSpL3odKkkWAB8Dfh3YBtycZENV3TPdzvaPuULIL0ZKmoa+n/46GdhaVfdX1ZPA1cCZU+5Jkp63en2kAiwGHhya3ga8fkq99MKkT7Ht7RHSgdbPXHxcjjS/vodKRtTqWTMla4A1bfIfkty3j9s7HHh4H5fdr/KRZ5X2S+8jttuFfe59Qv3s7TZ687kZoc+9Q7/7P9B6//lxZup7qGwDlgxNHw1s33OmqrocuPy5bizJ5qpa8VzXMw32Pj197r/PvUO/++9r732/pnIzsCzJMUleBLwL2DDlniTpeavXRypV9VSS84DrGNxSvL6q7p5yW5L0vNXrUAGoqo3Axv20ued8Cm2K7H16+tx/n3uHfvffy95T9azr2pIk7ZO+X1ORJB1ADJUxJFmV5L4kW5Osm3Y/oyRZn2RnkruGaocl2ZRkS3s9tNWT5NK2P3ckOWl6nUOSJUluSHJvkruTvKcv/Sd5SZKbkvxt6/2/tfoxSW5svX+u3UhCkhe36a3t/aXT6n1GkgVJbkvy1Tbdp94fSHJnktuTbG61A/5z0/pZmOQLSb7TPvtv6EvvczFU5jH0KJjTgeOBs5McP92uRvoksGqP2jrg+qpaBlzfpmGwL8vasAa4bD/1OJungPdV1XHASmBt+zPuQ/9PAKdW1QnAcmBVkpXAR4BLWu+PAOe2+c8FHqmqXwQuafNN23uAe4em+9Q7wJuqavnQ7bd9+NzA4JmFf1ZVvwScwOC/QV96n11VOcwxAG8ArhuaPh84f9p9zdLrUuCuoen7gKPa+FHAfW3848DZo+Y7EAbgWgbPc+tV/8AhwK0MnurwMHDQnp8hBncqvqGNH9TmyxR7PprBX16nAl9l8IXiXvTe+ngAOHyP2gH/uQFeAXx3zz+/PvQ+3+CRyvxGPQpm8ZR62VtHVtUOgPZ6RKsfsPvUTqmcCNxIT/pvp49uB3YCm4C/A35QVU+N6O8nvbf3HwVeuX87/il/APwn4Mdt+pX0p3cYPEHjz5Pc0p6cAf343BwL7AL+Zzv1+CdJXko/ep+ToTK/sR4F0zMH5D4leRnwReC9VfXYXLOOqE2t/6p6uqqWM/hX/8nAcaNma68HTO9J/jWws6puGS6PmPWA633IKVV1EoPTQ2uT/Ms55j2Q+j8IOAm4rKpOBH7IM6e6RjmQep+ToTK/sR4Fc4B6KMlRAO11Z6sfcPuU5IUMAuXTVfWlVu5N/wBV9QPgmwyuCy1MMvM9sOH+ftJ7e//ngN37t9OfOAV4W5IHGDzh+1QGRy596B2AqtreXncCX2YQ6n343GwDtlXVjW36CwxCpg+9z8lQmV+fHwWzAVjdxlczuFYxUz+n3VGyEnh05pB7GpIEuAK4t6ouHnrrgO8/yaIkC9v4wcCvMbjgegPwjjbbnr3P7NM7gL+odpJ8f6uq86vq6KpayuBz/RdV9Zv0oHeAJC9N8vKZceA04C568Lmpqv8LPJjk1a30ZuAeetD7vKZ9UacPA3AG8L8ZnCv/z9PuZ5YePwvsAP6Jwb9qzmVwvvt6YEt7PazNGwZ3tP0dcCewYsq9/yqDQ/k7gNvbcEYf+gdeC9zWer8L+L1WPxa4CdgKfB54cau/pE1vbe8fO+3PTuvrjcBX+9R76/Nv23D3zP+bffjctH6WA5vbZ+crwKF96X2uwW/US5I64+kvSVJnDBVJUmcMFUlSZwwVSVJnDBVJUmcMFUlSZwwVSVJnDBVJUmf+P2p/HFmJMyMXAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_rank_df['rank'].plot.hist(bins=50)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<matplotlib.axes._subplots.AxesSubplot at 0x7fea23631588>"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAZQAAAD8CAYAAABQFVIjAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3X2QHPV95/H3Z2b2SUISSAhb1gMSRnEs2+enDeCYpJIQsPD5LKcCFRE/kIQciRMqlzjJRSQHZXNO1ZG7CzmXiWMSSIguNjg4djYODrGNE5dzjqylwIAAmbXA1lo2SEboAWkfZuZ7f3TPajSa3Z3VTu/sqj+vqqnp/vWve3/dGs13fg/9a0UEZmZms1XodAHMzOzM4IBiZmZt4YBiZmZt4YBiZmZt4YBiZmZt4YBiZmZt4YBiZmZt4YBiZmZt4YBiZmZtUep0AebCueeeG+vXr+90MczMFpSHHnroQESsbDV/LgLK+vXrGRwc7HQxzMwWFEnfnkl+N3mZmVlbOKCYmVlbOKCYmVlbOKCYmVlbOKCYmVlbOKCYmVlbOKCYmVlbOKBY20QEA9/Yx4Gjo50uipl1QKYBRdJmSbslDUna1mR7j6R70+07JK1v2L5O0lFJv9PqMa1zHt77Ir/xyYe59fNPdbooZtYBmQUUSUXgduBKYBNwjaRNDdmuAw5GxIXAbcCtDdtvAz4/w2Nahww9dxSASjU6XBIz64QsaygXAUMRsScixoB7gC0NebYAd6fL9wGXSRKApHcBe4BdMzymdch4tdrpIphZB2UZUFYDe+vWh9O0pnkiogwcAlZIWgz8HvCh0zgmAJKulzQoaXD//v2nfRLWutHxJKBUwjUUszzKMqCoSVrjN81keT4E3BYRR0/jmElixB0R0R8R/StXtjxZps3CaDkJKG7xMsunLGcbHgbW1q2vAfZNkmdYUglYBrwAXAxcJemPgLOBqqQR4KEWjmkdMlYLKI4oZrmUZUDZCWyUtAH4LrAV+PmGPAPAtcDXgKuAByMigB+rZZD0QeBoRHw0DTrTHdM6ZLRcSd/dl2KWR5kFlIgoS7oBeAAoAndFxC5JtwCDETEA3AlslzREUjPZejrHzOocbGZqgeT4eLnDJTGzTsj0AVsRcT9wf0PazXXLI8DV0xzjg9Md0+aHWpPXmGsoZrnkO+WtbWpNXmX3oZjlkgOKtU2tZlKuOKCY5ZEDirXNWCUJKOMVN3mZ5ZEDirVNrWbiJi+zfHJAsbappnfIl11DMcslBxRrm9qkkOPuQzHLJQcUa5taHCl7kkizXHJAsbapTbniUV5m+eSAYm1zosnLNRSzPHJAsbapTVvvB2yZ5ZMDirXNRA3FAcUslxxQrG0qVQ8bNsszBxRrm9p9KNXwM1HM8sgBxdqmvu/Ez5c3yx8HFGub+oDiocNm+ZNpQJG0WdJuSUOStjXZ3iPp3nT7Dknr0/SLJD2Svr4h6Wfq9nlW0mPptsEsy28zU2vyAgcUszzK7AFbkorA7cDlJM+O3ylpICKeqMt2HXAwIi6UtBW4Ffg54HGgP31C4yrgG5L+ISJqjwL8yYg4kFXZ7fSU3eRllmtZ1lAuAoYiYk9EjAH3AFsa8mwB7k6X7wMuk6SIOFYXPHoB/9xdAOo74n0viln+ZBlQVgN769aH07SmedIAcghYASDpYkm7gMeAX60LMAH8s6SHJF2fYflthip1TV6+W94sf7J8pryapDX+bJ00T0TsAF4j6dXA3ZI+nz6D/q0RsU/SecAXJD0VEV855Y8nweZ6gHXr1s3mPKxF1SoUC6JSDfehmOVQljWUYWBt3foaYN9keSSVgGXAC/UZIuJJ4CXgten6vvT9eeAzJE1rp4iIOyKiPyL6V65cOeuTselVqkFPKflIecZhs/zJMqDsBDZK2iCpG9gKDDTkGQCuTZevAh6MiEj3KQFIOh94FfCspMWSlqTpi4ErSDrwbR6oxImA4meimOVPZk1e6QitG4AHgCJwV0TsknQLMBgRA8CdwHZJQyQ1k63p7pcC2ySNA1Xg1yLigKQLgM9IqpX9ExHxT1mdg81MtRr0lIrAuJu8zHIoyz4UIuJ+4P6GtJvrlkeAq5vstx3Y3iR9D/D69pfU2qFcDc7qTWsobvIyyx3fKW9tU63vQ3ENxSx3HFCsbZI+lCLgTnmzPHJAsbapuIZilmsOKNY21Qh6ujxs2CyvHFCsbSrVE01eHjZslj8OKNYWEUE1cJOXWY45oFhb1CaD9J3yZvnlgGJtUZsYsrfLTV5meeWAYm1Rq5B0pzWUimsoZrnjgGJtUauheC4vs/xyQLG2ONGHkt7Y6OehmOWOA4q1RfWUTnnXUMzyxgHF2mKiyavLTV5meeWAYm3R2OTlTnmz/HFAsbaoBZRud8qb5VamAUXSZkm7JQ1J2tZke4+ke9PtOyStT9MvkvRI+vqGpJ9p9ZjWGbWAUiyIYkG+sdEshzILKJKKwO3AlcAm4BpJmxqyXQccjIgLgduAW9P0x4H+iHgDsBn4uKRSi8e0DqimfShFiVJBnnrFLIeyrKFcBAxFxJ6IGAPuAbY05NkC3J0u3wdcJkkRcSwiyml6L1D7dmrlmNYB9TWUrmLBo7zMcijLgLIa2Fu3PpymNc2TBpBDwAoASRdL2gU8Bvxqur2VY1oH1GoohVqTl+9DMcudLAOKmqQ1/mydNE9E7IiI1wA/AtwoqbfFYyYHlq6XNChpcP/+/TMotp2OWo2kVBBdRTHuGopZ7mQZUIaBtXXra4B9k+WRVAKWAS/UZ4iIJ4GXgNe2eMzafndERH9E9K9cuXIWp2GtqDV5FSRKhYJrKGY5lGVA2QlslLRBUjewFRhoyDMAXJsuXwU8GBGR7lMCkHQ+8Crg2RaPaR1QG9RVLIhS0Z3yZnlUyurAEVGWdAPwAFAE7oqIXZJuAQYjYgC4E9guaYikZrI13f1SYJukcaAK/FpEHABodsyszsFaV7tTvlhImr3cKW+WP5kFFICIuB+4vyHt5rrlEeDqJvttB7a3ekzrvJOavIoF34dilkO+U97aYuI+lEJyH4rvlDfLHwcUa4uJ+1CU3ofiTnmz3HFAsbaov7GxVHQfilkeOaBYW5wUUDz1ilkuOaBYW1Tq7pQvFdwpb5ZHDijWFtW6PpRS0Z3yZnnkgGJtcerkkK6hmOWNA4q1xcTkkJ6+3iy3HFCsLSqNU694lJdZ7jigWFvUmriKBU8OaZZXDijWFifdKe9OebNcckCxtpho8pLo8rBhs1xyQLG2qA0bLhSgWNTEqC8zyw8HFGuLSl2TV5cnhzTLJQcUa4vKSTc2ulPeLI8cUKwtTumUd5OXWe5kGlAkbZa0W9KQpG1NtvdIujfdvkPS+jT9ckkPSXosff+pun3+JT3mI+nrvCzPwVpTu5ExafJyDcUsjzJ7YqOkInA7cDkwDOyUNBART9Rluw44GBEXStoK3Ar8HHAA+E8RsU/Sa0ke+bu6br93R8RgVmW3mavWTQ5ZLIhqJB31hYI6XDIzmytZ1lAuAoYiYk9EjAH3AFsa8mwB7k6X7wMuk6SIeDgi9qXpu4BeST0ZltVm6eQHbCVBxHfLm+VLlgFlNbC3bn2Yk2sZJ+WJiDJwCFjRkOdngYcjYrQu7S/T5q6bJDX9CSzpekmDkgb3798/m/OwFlRO6kNJPla+F8UsX7IMKM2+6Bt/sk6ZR9JrSJrBfqVu+7sj4nXAj6Wv9zb74xFxR0T0R0T/ypUrZ1Rwm7mJ+1DSySEBDx02y5ksA8owsLZufQ2wb7I8kkrAMuCFdH0N8BngfRHxrdoOEfHd9P0I8AmSpjXrsJMmh0wDim9uNMuXLAPKTmCjpA2SuoGtwEBDngHg2nT5KuDBiAhJZwP/CNwYEf9WyyypJOncdLkLeAfweIbnYC2qpM1bBXGiycsjvcxyJbOAkvaJ3EAyQutJ4FMRsUvSLZLemWa7E1ghaQj4AFAbWnwDcCFwU8Pw4B7gAUmPAo8A3wX+PKtzsNZVIigWhOo65X0vilm+ZDZsGCAi7gfub0i7uW55BLi6yX4fBj48yWHf3M4yWntUqskIL4BSwTUUszxqqYYi6dOS/qMk31lvTVUjSOMIpaI75c3yqNUA8THg54GnJf0PST+cYZlsAapU45QaijvlzfKlpYASEV+MiHcDbwKeBb4g6f9J+sW0c9xyrlJ3V/yJGoqbvMzypOUmLEkrgF8Afhl4GPg/JAHmC5mUzBaUatopD/hOebOcaqlTXtLfAT8MbCeZY+t76aZ7JXlOLaNcjYn7T9wpb5ZPrY7y+ot0xNYEST0RMRoR/RmUyxaYajUoqLHJyzUUszxptcmr2RDer7WzILawVaonmrwmaiiey8ssV6asoUh6OckEjn2S3siJubeWAosyLpstIJU4UUPpKSUBxZ3yZvkyXZPX20g64tcAf1yXfgT4/YzKZAtQta6G0tOVBJSRcQcUszyZMqBExN3A3ZJ+NiI+PUdlsgWoEkwElN5SEYCR8Uoni2Rmc2y6Jq/3RMT/BdZL+kDj9oj44ya7WQ4lnfLJcq2GMlp2DcUsT6Zr8lqcvp+VdUFsYStXqxOd8a6hmOXTdE1eH0/fPzQ3xbGFqlJl4k5511DM8qnVySH/SNJSSV2SviTpgKT3ZF04WziSO+WT5R7XUMxyqdX7UK6IiMMkD7QaBn4I+N3MSmULTv3kkMVC8kwU11DM8qXVgFKbAPLtwCcj4oVWdpK0WdJuSUOStjXZ3iPp3nT7Dknr0/TLJT0k6bH0/afq9nlzmj4k6SOSmj2X3uZYMn39iX+K3lLRNRSznGk1oPyDpKeAfuBLklYCI1PtIKkI3A5cCWwCrpG0qSHbdcDBiLgQuA24NU0/QDJn2OtIHhG8vW6fjwHXAxvT1+YWz8EyVF9DgaQfxTUUs3xpdfr6bcBbgP6IGAdeArZMs9tFwFBE7ImIMeCeJvtsAe5Ol+8DLpOkiHg4Ival6buA3rQ2swpYGhFfi4gA/hp4VyvnYNmqn3oFkn4U11DM8mUmjwB+Ncn9KPX7/PUU+VcDe+vWh4GLJ8sTEWVJh4AVJDWUmp8FHo6IUUmr0+PUH3P1DM7BMlKpBt2lE79PXEMxy59Wp6/fDrwSeASo/eys1RAm3a1JWuP0s1PmkfQakmawK2ZwzNq+15M0jbFu3bopimntUImTayi9pSKjrqGY5UqrNZR+YFPazNSqYWBt3foaYN8keYbTms8y4AUASWuAzwDvi4hv1eVfM80xAYiIO4A7APr7+z2Pesbqp68H11DM8qjVTvnHgZfP8Ng7gY2SNkjqBrYCAw15Bkg63QGuAh6MiJB0NvCPwI0R8W+1zOmDvY5IuiQd3fU+4O9nWC7LQLMaivtQzPKl1RrKucATkr4OjNYSI+Kdk+2Q9oncADwAFIG7ImKXpFuAwYgYAO4EtksaIqmZbE13vwG4ELhJ0k1p2hUR8TzwfuCvgD7g8+nLOqxS5ZQaytGj5Q6WyMzmWqsB5YOnc/D0KY/3N6TdXLc8AlzdZL8P0/yhXkTEIPDa0ymPZSeZvv7Eem+pyGjZNRSzPGkpoETEv0o6H9gYEV+UtIik1mEGJE1etckhAXq7Cn4eilnOtDqX138muU/k42nSauCzWRXKFp5K9eQ75fu6ixwbcw3FLE9a7ZT/deCtwGGAiHgaOC+rQtnCk9wpf2J9SW8XR0bGO1cgM5tzrQaU0fRudwDSIb4eimsTGmsoS3pKjJarjHnosFlutBpQ/lXS7wN9ki4H/hb4h+yKZQtNNU6ey2tJb9I9d3TUI73M8qLVgLIN2A88BvwKycit/5ZVoWzhaZzL66zeZIJqN3uZ5Uero7yqkj4LfDYi9mdcJluAGqevr9VQjoy4hmKWF1PWUJT4oKQDwFPAbkn7Jd081X6WP+VqUGoSUA67hmKWG9M1ef0myeiuH4mIFRGxnGTG4LdK+q3MS2cLRqVhLq+lE01erqGY5cV0AeV9wDUR8UwtISL2AO9Jt5kBtTvlm3TKO6CY5cZ0AaUrIg40Jqb9KF1N8ltONU4OucSd8ma5M11AGTvNbZYz1YbJId0pb5Y/043yer2kw03SBfRmUB5boJIayon1rmKB3q4CR3wfilluTBlQIsITQNq0IiKdeuXkB2qe1ePpV8zypNUbG80mVU0n4SkWTv44Le0tcdhNXma5kWlAkbRZ0m5JQ5K2NdneI+nedPsOSevT9BWSvizpqKSPNuzzL+kxH0lfnqSywyppRCk2fJqW9JY8ysssR1p9wNaMSSoCtwOXkzwLfqekgYh4oi7bdcDBiLhQ0lbgVuDngBHgJpIHaTV7mNa70wdt2TxQjSSg1N8pD55x2CxvsqyhXAQMRcSedKbie4AtDXm2AHeny/cBl0lSRLwUEV8lCSw2z03UUBr6UJb2ucnLLE+yDCirgb1168NpWtM8EVEGDgErWjj2X6bNXTdJDd9iNucqUWvyaggovV0cPu4ailleZBlQmn3RNz5DpZU8jd4dEa8Dfix9vbfpH5eulzQoaXD/fs9nmaVqWkMpNMT2ZX1dHHJAMcuNLAPKMLC2bn0NsG+yPOlDu5YBL0x10Ij4bvp+BPgESdNas3x3RER/RPSvXLnytE7AWlNr8ioVG5u8uhgtVxkZ96OAzfIgy4CyE9goaYOkbmArMNCQZwC4Nl2+CngwIiatoUgqSTo3Xe4C3gE83vaS24xUJqmhLPXd8ma5ktkor4goS7oBeAAoAndFxC5JtwCDETEA3AlslzREUjPZWttf0rPAUqBb0ruAK4BvAw+kwaQIfBH486zOwVozaR9KXzKf1+GRcVYu6ZnzcpnZ3MosoABExP0kT3esT7u5bnkEuHqSfddPctg3t6t81h6Tj/JKAor7UczywXfK26xVq8l7430otWeieKSXWT44oNisnWjyOjl9WV/tqY3uQzHLAwcUm7VJO+Xd5GWWKw4oNmu1qVdKp0wO6SYvszxxQLFZK1eaN3n1dhXpLhU47Pm8zHLBAcVmbWJyyCaz4Czr8/QrZnnhgGKzVk77ULoaqyikz0Q57k55szxwQLFZK1eSccONNzZC0jHvJi+zfHBAsVmr1VBKTQKKJ4g0yw8HFJu1E5NDNmvych+KWV44oNisjU/Z5OWHbJnlhQOKzVplolO+SUDpTZq8pphE2szOEA4oNmu1PpRmNZRlfV1UqsGxMT8TxexM54Bis1a7sbHxTnk4eQp7MzuzOaDYrJXT6YYbn9gIJ6Zf8UgvszOfA4rNWmWaYcOAb240y4FMA4qkzZJ2SxqStK3J9h5J96bbd0han6avkPRlSUclfbRhnzdLeizd5yNSk/k+bE6dmMur+Sgv8ASRZnmQWUCRVARuB64ENgHXSNrUkO064GBEXAjcBtyapo8ANwG/0+TQHwOuBzamr83tL73NxNRTr7jJyywvsqyhXAQMRcSeiBgD7gG2NOTZAtydLt8HXCZJEfFSRHyVJLBMkLQKWBoRX4tkHOpfA+/K8BysBbU+lMmmXgF3ypvlQZYBZTWwt259OE1rmiciysAhYMU0xxye5pgASLpe0qCkwf3798+w6DYTJ0Z5NeuUrzV5uQ/F7EyXZUBp1rfReHdbK3lOK39E3BER/RHRv3LlyikOabM11dQrpWKBxd1FN3mZ5UCWAWUYWFu3vgbYN1keSSVgGfDCNMdcM80xbY6N14YNN6mhQDLS68XjY3NZJDPrgCwDyk5go6QNkrqBrcBAQ54B4Np0+SrgwZhijo6I+B5wRNIl6eiu9wF/3/6i20xUpmjyAjhvaS/PHR5pus3MzhylrA4cEWVJNwAPAEXgrojYJekWYDAiBoA7ge2ShkhqJltr+0t6FlgKdEt6F3BFRDwBvB/4K6AP+Hz6sg6aauoVgFec3ctT3z8yl0Uysw7ILKAARMT9wP0NaTfXLY8AV0+y7/pJ0geB17avlDZb5WqVYkFMdkvQy5f28eWn9hMRk+Yxs4XPd8rbrJWrMWlzFyQ1lOPjFY/0MjvDOaDYrFUqUweUly/rBWDfoeNzVSQz6wAHFJu1cjUm7T8BWLd8EQDf/sFLc1UkM+sABxSbtXK12nTalZpXrjwLgG8+d3SuimRmHeCAYrNWrkxdQ1ncU2LNOX08/bwDitmZzAHFZm26TnmAH3rZEnZ///AclcjMOsEBxWatUo2m067U+w9rlvH080c9SaTZGcwBxWZtvFKdtobSf/5yIuDh77w4R6Uys7nmgGKzVplmlBfAG9adTUHw0LcPzlGpzGyuOaDYrJVbaPI6q6fEq1ctZeczU839aWYLmQOKzVq5hSYvgB995Qoe+vZBjo35jnmzM5EDis1aUkOZPqD8+A+tZKxS5d/3/GAOSmVmc80BxWat0sKwYYAfWb+c3q4CX/nmgTkolZnNNQcUm7Xpbmys6e0qcvGGFXzlm34ks9mZyAHFZm26qVfqXXLBCvYceIkXj/kJjmZnmkwDiqTNknZLGpK0rcn2Hkn3ptt3SFpft+3GNH23pLfVpT8r6TFJj0gazLL81ppWhg3XvHrVEgA/cMvsDJRZQJFUBG4HrgQ2AddI2tSQ7TrgYERcCNwG3Jruu4nk6Y2vATYDf5oer+YnI+INEdGfVfmtdWOVoFRo7aO0adVSAJ78nqdhMTvTZFlDuQgYiog9ETEG3ANsacizBbg7Xb4PuCx9VvwW4J6IGI2IZ4Ch9Hg2D42WK/R0tfZRWrmkh3MWdXnmYbMzUJYBZTWwt259OE1rmiciysAhYMU0+wbwz5IeknR9BuW2GRorV+lpsQ9FEuuWL2L44LGMS2Vmcy3LZ8o3a1SPFvNMte9bI2KfpPOAL0h6KiK+csofT4LN9QDr1q1rvdQ2Y2PlKt2l1n+brDlnkZu8zM5AWdZQhoG1detrgH2T5ZFUApYBL0y1b0TU3p8HPsMkTWERcUdE9EdE/8qVK2d9Mja5scpMA0ofwy8ep1pt/H1hZgtZlgFlJ7BR0gZJ3SSd7AMNeQaAa9Plq4AHIyLS9K3pKLANwEbg65IWS1oCIGkxcAXweIbnYC0YHa/SM8OAMlaucuDoaIalMrO5llmTV0SUJd0APAAUgbsiYpekW4DBiBgA7gS2SxoiqZlsTffdJelTwBNAGfj1iKhIehnwmaTfnhLwiYj4p6zOwVoz8xpK8oz5vQePc97S3qyKZWZzLMs+FCLifuD+hrSb65ZHgKsn2fcPgT9sSNsDvL79JbXTVakGlWrQXSxOnzm15pw+AIYPHuPN55+TVdHMbI75TnmblbFyFWBGNZTVEwHleCZlMrPOcECxWRktV4CZBZRF3SVWLO720GGzM4wDis3K6dRQANYsX+QaitkZxgHFZuX4eFJD6etqvQ8Fkn6UvS+4hmJ2JnFAsVk5NpYElEXdMwsoa89ZxHcb7kX5yjf387bbvsLj3z3U1jKa2dxwQLFZqQWUvpkGlOV9jFeC546MTKT97y98k93PHeGurz7T1jKa2dxwQLFZOV6rocy4ySu5F6XWj3J8rMKutGYy+O2DbSyhmc0VBxSblWNjZSAZuTUTa9Ohw9/5QdKP8vi+Q5SrwSUXLOc7Lxzj+cMjU+1uZvOQA4rNSq1TflHPTJu8FtFVFE8/n0xj//B3klrJL751AwCPDrsfxWyhcUCxWTndTvmuYoELz1syMevww995kXXLF3HpheciwROejdhswXFAsVk5fHwcgCW9XTPe99WrkoASEex89gX6zz+HxT0lNqxYzK59rqGYLTQOKDYrLx4fp6soFs+whgLwhrVn8/yRUb745PMcODrGxRcsB2DTK5aya59rKGYLjQOKzcqLx8ZZ1tdNOgP0jFz26pcB8NufegSAt1xwLpAElOGDx3nx2Fj7CmpmmXNAsVl58dgY5yyaeXMXwOqz+7jkguUcHinzo69cwboVyVDiizesAOArTx9oWznNLHuZTl9vZ779R0ZZcVb3ae//ka1v5HOPfo93vH7VRNob1p7NuWd1M/DIPt75+le0o5hmNgcyraFI2ixpt6QhSduabO+RdG+6fYek9XXbbkzTd0t6W6vHtLm19+Ax1qY3KZ6O85b28kuXbuC8JScetFUsiPdesp4vPvkcd371GZKHeJrZfJdZQJFUBG4HrgQ2AddI2tSQ7TrgYERcCNwG3Jruu4nk6Y2vATYDfyqp2OIxbY4cHS3z3OFR1i4//YAymff/xCv56Ve/jP/+uSf4vU8/OjFNvpnNX1k2eV0EDKVPWUTSPcAWksf61mwBPpgu3wd8VEnv7hbgnogYBZ5JHxF8UZpvumPaHPn3b/0ASJqo2q27VOCO976ZP/niN/nIg0M8/fxRfvvyV9HbVeD7h0fYf2SUA0dHGStXOWdxN+ct6eXlS3tZ1FOku1igVBSlQoHuYoG+7iKLe4r0lopUIxgpVxkZr3BkpMyh4+O8eGyMl0YrSFCQKBZEqSiW9pZY0ttFX1eRrmKBrqLo7SrS21WkWBDVajBarnJ8vMLIeGXifWS8wmi5Sm9XkbN6SizqLrK4uzRRttMZwJCFSjUYr1QZr1QpV4KXxsocPl6mqyiW9XWxtK+L3hlOqWP5lmVAWQ3srVsfBi6eLE/6DPpDwIo0/d8b9l2dLk93zLb55bt38mw6NUhjs0tMstLYOFO/36nb6veLybdN0eLTluNPsV/j1vptR0bKvHxpLxdtWD55AWehUBAfuOJV/PCqpfzu336D99y546TtpULy5T+aPpNlLnUVxXjl9JriSmnAKhUKSfAqiEJBFBriTDVq1zsmrnsSi4QEmlhP8jUrTS1PNaBcqTJeORFEqi0Uv6dUYGlfVxoIk4Bbe69p9hls9bM3UU6B6s6rkC5MF3qnC87zI3R31ud+41J6SnPzwyDLgNLs37LxozRZnsnSmzXRNf1vIel64HqAdevWTV7KKZy/YvHJ/xANpapfrf9gNxa+/jN/6rbJ9+Ok/U7eOtkxG/9/1e93yjadnLOV49dv6y4W+fmL12X+K/btr1vFpRvP5dG9hyhXq7x8WS/nLenl7L4uCgVxbCxpenvu8AjHxyrJL+701/dYWhs5Npa8SoWkltHTVWBJb4llfV0s6+virJ4ugqBSDapVGKtUOTpa5vDxcUbL1ZOOdTytgXSxlc58AAAGe0lEQVQXC/R2FenrSt+7i/SUkveuohgdr/LSWJljoxVeGivz0miZsXJStko16t6rVKpxyo+IQiG5+qr7Yg1ODjIRJ/49asGm7ignBaKuYoFSoUBXSXQVCsl6URM1ukXdRZb1dTFWCQ4dH+dw+jp0fJxyNahGcrxqBNWY/HOnibTWPttE7bxi4vyC5O9MadrN7nuDU787spRlQBkG1tatrwH2TZJnWFIJWAa8MM2+0x0TgIi4A7gDoL+//7Q+WTe9w90z88XS3i4u3Xhu022LuktsOLfEhnMXz3GpzKxelqO8dgIbJW2Q1E3SyT7QkGcAuDZdvgp4MJL68wCwNR0FtgHYCHy9xWOamVkHZFZDSftEbgAeAIrAXRGxS9ItwGBEDAB3AtvTTvcXSAIEab5PkXS2l4Ffj4gKQLNjZnUOZmbWOuVhjH9/f38MDg52uhhmZguKpIcior/V/J56xczM2sIBxczM2sIBxczM2sIBxczM2sIBxczM2iIXo7wk7Qe+3elyzMC5wEJ9GIjL3jkLufwue+dMVf7zI2JlqwfKRUBZaCQNzmSo3nzisnfOQi6/y9457Sy/m7zMzKwtHFDMzKwtHFDmpzs6XYBZcNk7ZyGX32XvnLaV330oZmbWFq6hmJlZWzigdJCk/ynpKUmPSvqMpLPrtt0oaUjSbklvq0vfnKYNSdrWmZKfar6Wq56ktZK+LOlJSbsk/Zc0fbmkL0h6On0/J02XpI+k5/SopDd19gxAUlHSw5I+l65vkLQjLfu96WMdSB/9cG9a9h2S1ne43GdLui/9vD8p6S0L7Lr/VvqZeVzSJyX1ztdrL+kuSc9LerwubcbXWtK1af6nJV3b7G+dIiL86tALuAIopcu3Aremy5uAbwA9wAbgWyTT9RfT5QuA7jTPpnlwHvOyXE3KuQp4U7q8BPhmeq3/CNiWpm+r+3d4O/B5kucLXgLsmAfn8AHgE8Dn0vVPAVvT5T8D3p8u/xrwZ+nyVuDeDpf7buCX0+Vu4OyFct1JHj/+DNBXd81/Yb5ee+DHgTcBj9elzehaA8uBPen7OenyOdP+7U7+Q/l10ofgZ4C/SZdvBG6s2/YA8Jb09UBd+kn5Olj2eVmuFsr998DlwG5gVZq2CtidLn8cuKYu/0S+DpV3DfAl4KeAz6VfAgc48aNk4t+h9plJl0tpPnWo3EvTL2Q1pC+U674a2Jt+uZbSa/+2+XztgfUNAWVG1xq4Bvh4XfpJ+SZ7uclr/vglkl8KcOIDXDOcpk2W3mnztVyTSpsh3gjsAF4WEd8DSN/PS7PNt/P6E+C/AtV0fQXwYkSU0/X68k2UPd1+KM3fCRcA+4G/TJvr/kLSYhbIdY+I7wL/C/gO8D2Sa/kQC+Pa18z0Wp/Wv4EDSsYkfTFtd218banL8wckT6b8m1pSk0PFFOmdNl/L1ZSks4BPA78ZEYenytokrSPnJekdwPMR8VB9cpOs0cK2uVYiaYL5WES8EXiJpNllMvOp7KT9DVtImp9fASwGrmySdT5e++m09bsms0cAWyIifnqq7Wln1zuAyyKtW5L8Glhbl20NsC9dniy9k6Yq77wiqYskmPxNRPxdmvycpFUR8T1Jq4Dn0/T5dF5vBd4p6e1AL0kz0p8AZ0sqpb+E68tXK/uwpBKwjOQx250wDAxHxI50/T6SgLIQrjvATwPPRMR+AEl/B/woC+Pa18z0Wg8DP9GQ/i/T/RHXUDpI0mbg94B3RsSxuk0DwNZ0tMgGYCPwdWAnsDEdXdJN0uE3MNflbmK+luskkgTcCTwZEX9ct2kAqI1iuZakb6WW/r50JMwlwKFas8Fci4gbI2JNRKwnub4PRsS7gS8DV6XZGsteO6er0vwd+ZUcEd8H9kp6VZp0GfAEC+C6p74DXCJpUfoZqpV/3l/7OjO91g8AV0g6J62hXZGmTa1THV1+BcAQSTvlI+nrz+q2/QHJyKndwJV16W8nGZ30LeAPOn0O871cDWW8lKTa/mjdNX87Sfv2l4Cn0/flaX4Bt6fn9BjQ3+lzSMv1E5wY5XUByY+NIeBvgZ40vTddH0q3X9DhMr8BGEyv/WdJRg4tmOsOfAh4Cngc2E4yAnNeXnvgkyR9PeMkNY3rTudak/TrDqWvX2zlb/tOeTMzaws3eZmZWVs4oJiZWVs4oJiZWVs4oJiZWVs4oJiZWVs4oJiZWVs4oJiZWVs4oJiZWVv8f88807szlvWmAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_rank_df['rank'].plot.density()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
A simple prioritizing algorithm using log based weighting scheme. The trained weights are on Azure blob storage. Do:
`make models:pull FILENAME=/output/models/simplerank/simplerank.tar.xz` to download the compressed models. Make sure to **uncompress** the archive. The files inside the archives include:
- `from_weights.csv`:  Weights from sender information
- `thread_senders_weight.csv`: Weights from sender information in threads
- `thread_weights.csv`: Weights from thread subject and thread activity
- `thread_term_weights.csv`: Weights from terms in thread subjects
- `msg_terms_weight.csv`: Weights from frequent terms in message content